### PR TITLE
Add Extra types to Disc Items

### DIFF
--- a/code/TheDiscDb.Client/ClipboardService.cs
+++ b/code/TheDiscDb.Client/ClipboardService.cs
@@ -4,8 +4,8 @@ namespace TheDiscDb.Client;
 
 public interface IClipboardService
 {
-    ValueTask<string> ReadTextAsync();
-    ValueTask WriteTextAsync(string text);
+    ValueTask<string> ReadTextAsync(CancellationToken cancellationToken = default);
+    ValueTask WriteTextAsync(string text, CancellationToken cancellationToken = default);
 }
 
 public sealed class ClipboardService : IClipboardService
@@ -17,13 +17,13 @@ public sealed class ClipboardService : IClipboardService
         this.jsRuntime = jsRuntime;
     }
 
-    public ValueTask<string> ReadTextAsync()
+    public ValueTask<string> ReadTextAsync(CancellationToken cancellationToken = default)
     {
-        return jsRuntime.InvokeAsync<string>("navigator.clipboard.readText");
+        return jsRuntime.InvokeAsync<string>("navigator.clipboard.readText", cancellationToken: cancellationToken);
     }
 
-    public ValueTask WriteTextAsync(string text)
+    public ValueTask WriteTextAsync(string text, CancellationToken cancellationToken = default)
     {
-        return jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+        return jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", cancellationToken, text);
     }
 }

--- a/code/TheDiscDb.Client/NavigationExtensions.cs
+++ b/code/TheDiscDb.Client/NavigationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using TheDiscDb.InputModels;
+using TheDiscDb.Naming;
 
 namespace TheDiscDb;
 
@@ -209,18 +210,26 @@ public static class NavigationExtensions
                 continue;
             }
 
-            if (features.TryGetValue(title.Item.Type, out DiscFeature? f))
+            // Collapse all extra-family types under a single "Extra" feature
+            // so the disc summary shows a unified count instead of one line
+            // per sub-category (Interview, Featurette, etc.). The granular
+            // type is still preserved on the underlying DiscItemReference.
+            string featureKey = ItemTypeNames.IsExtra(title.Item.Type)
+                ? ItemTypeNames.Extra
+                : title.Item.Type;
+
+            if (features.TryGetValue(featureKey, out DiscFeature? f))
             {
                 f.Count++;
             }
             else
             {
                 bool hasChapters = title.Item.Chapters.Any();
-                features[title.Item.Type] = new DiscFeature
+                features[featureKey] = new DiscFeature
                 {
                     HasChapters = hasChapters,
                     Count = 1,
-                    Type = title.Item.Type
+                    Type = featureKey
                 };
             }
         }
@@ -254,7 +263,7 @@ public class DiscFeature
                     return Count + " movies";
                 }
             }
-            else if (Type == "Extra")
+            else if (ItemTypeNames.IsExtra(Type))
             {
                 if (Count == 1)
                 {

--- a/code/TheDiscDb.Client/Pages/Contribute/IdentifyDiscItems.razor
+++ b/code/TheDiscDb.Client/Pages/Contribute/IdentifyDiscItems.razor
@@ -88,27 +88,20 @@
                             @if (this.mediaType != null && this.mediaType.Equals("movie", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 <DropDownMenuItem Text="Main Movie" data-type="MainMovie"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Extra" data-type="Extra"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Other" data-type="Other"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Interview" data-type="Interview"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Featurette" data-type="Featurette"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Scene" data-type="Scene"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Music" data-type="Music"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Short" data-type="Short"></DropDownMenuItem>
                             }
                             @if (this.mediaType != null && this.mediaType.Equals("series", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 <DropDownMenuItem Text="Episode" data-type="Episode"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Extra" data-type="Extra"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Other" data-type="Other"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Interview" data-type="Interview"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Featurette" data-type="Featurette"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Scene" data-type="Scene"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Music" data-type="Music"></DropDownMenuItem>
-                                <DropDownMenuItem Text="Short" data-type="Short"></DropDownMenuItem>
                             }
+                            <DropDownMenuItem Text="Extra" data-type="Extra"></DropDownMenuItem>
                             <DropDownMenuItem Text="Deleted Scene" data-type="DeletedScene"></DropDownMenuItem>
                             <DropDownMenuItem Text="Trailer" data-type="Trailer"></DropDownMenuItem>
+                            <DropDownMenuItem Text="Featurette" data-type="Featurette"></DropDownMenuItem>
+                            <DropDownMenuItem Text="Interview" data-type="Interview"></DropDownMenuItem>
+                            <DropDownMenuItem Text="Scene" data-type="Scene"></DropDownMenuItem>
+                            <DropDownMenuItem Text="Music" data-type="Music"></DropDownMenuItem>
+                            <DropDownMenuItem Text="Short" data-type="Short"></DropDownMenuItem>
+                            <DropDownMenuItem Text="Other" data-type="Other"></DropDownMenuItem>
                         </DropDownMenuItems>
                     </SfDropDownButton>
                 }

--- a/code/TheDiscDb.Client/Pages/Contribute/IdentifyDiscItems.razor
+++ b/code/TheDiscDb.Client/Pages/Contribute/IdentifyDiscItems.razor
@@ -89,11 +89,23 @@
                             {
                                 <DropDownMenuItem Text="Main Movie" data-type="MainMovie"></DropDownMenuItem>
                                 <DropDownMenuItem Text="Extra" data-type="Extra"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Other" data-type="Other"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Interview" data-type="Interview"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Featurette" data-type="Featurette"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Scene" data-type="Scene"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Music" data-type="Music"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Short" data-type="Short"></DropDownMenuItem>
                             }
                             @if (this.mediaType != null && this.mediaType.Equals("series", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 <DropDownMenuItem Text="Episode" data-type="Episode"></DropDownMenuItem>
                                 <DropDownMenuItem Text="Extra" data-type="Extra"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Other" data-type="Other"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Interview" data-type="Interview"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Featurette" data-type="Featurette"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Scene" data-type="Scene"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Music" data-type="Music"></DropDownMenuItem>
+                                <DropDownMenuItem Text="Short" data-type="Short"></DropDownMenuItem>
                             }
                             <DropDownMenuItem Text="Deleted Scene" data-type="DeletedScene"></DropDownMenuItem>
                             <DropDownMenuItem Text="Trailer" data-type="Trailer"></DropDownMenuItem>

--- a/code/TheDiscDb.Client/Pages/Contribute/IdentifyDiscItems.razor.cs
+++ b/code/TheDiscDb.Client/Pages/Contribute/IdentifyDiscItems.razor.cs
@@ -199,7 +199,7 @@ public partial class IdentifyDiscItems : CancellableComponentBase
             ContributionId = this.ContributionId!,
             DiscId = this.DiscId!
         };
-        var response = await this.ContributionClient.GetDiscLogs.ExecuteAsync(input);
+        var response = await this.ContributionClient.GetDiscLogs.ExecuteAsync(input, this.CancellationToken);
         if (response?.Data != null && response.IsSuccessResult())
         {
             this.allTitles = response.Data.DiscLogs.DiscLogs!.Info!.Titles.AsQueryable();
@@ -258,7 +258,7 @@ public partial class IdentifyDiscItems : CancellableComponentBase
             var episodeResults = await ContributionClient.GetEpisodeNames.ExecuteAsync(new EpisodeNamesInput
             {
                 ContributionId = this.ContributionId!
-            });
+            }, this.CancellationToken);
             if (episodeResults?.Data != null && episodeResults.IsSuccessResult())
             {
                 this.episodeNames = episodeResults.Data.EpisodeNames;
@@ -268,7 +268,7 @@ public partial class IdentifyDiscItems : CancellableComponentBase
         var externalMetadataResponse = await ContributionClient.GetExternalDataForContribution.ExecuteAsync(new ExternalDataForContributionInput
         {
             ContributionId = this.ContributionId!
-        });
+        }, this.CancellationToken);
 
         if (externalMetadataResponse?.Data != null && externalMetadataResponse.IsSuccessResult())
         {
@@ -961,7 +961,7 @@ public partial class IdentifyDiscItems : CancellableComponentBase
 
         try
         {
-            var clipboardText = await this.ClipboardService.ReadTextAsync();
+            var clipboardText = await this.ClipboardService.ReadTextAsync(this.CancellationToken);
             if (ChapterParser.TryParseChapters(clipboardText, out var names))
             {
                 this.clipboardHasChapters = true;

--- a/code/TheDiscDb.Core/ImportModels/DiscFile.cs
+++ b/code/TheDiscDb.Core/ImportModels/DiscFile.cs
@@ -15,6 +15,18 @@
         public ICollection<DiscFileItem> DeletedScenes { get; set; } = new HashSet<DiscFileItem>();
         public ICollection<DiscFileItem> Trailers { get; set; } = new HashSet<DiscFileItem>();
         public ICollection<DiscFileItem> MainMovies { get; set; } = new HashSet<DiscFileItem>();
+
+        // Sub-categories of Extra. Each is bucketed separately so the
+        // finalize step can preserve the granular Type when writing back to
+        // the disc file, while still being treated as Extras by anything
+        // that calls ItemTypeNames.IsExtra(...).
+        public ICollection<DiscFileItem> Others { get; set; } = new HashSet<DiscFileItem>();
+        public ICollection<DiscFileItem> Interviews { get; set; } = new HashSet<DiscFileItem>();
+        public ICollection<DiscFileItem> Featurettes { get; set; } = new HashSet<DiscFileItem>();
+        public ICollection<DiscFileItem> Scenes { get; set; } = new HashSet<DiscFileItem>();
+        public ICollection<DiscFileItem> Musics { get; set; } = new HashSet<DiscFileItem>();
+        public ICollection<DiscFileItem> Shorts { get; set; } = new HashSet<DiscFileItem>();
+
         public ICollection<DiscFileItem> Unknown { get; set; } = new HashSet<DiscFileItem>();
     }
 }

--- a/code/TheDiscDb.Core/SummaryFileParser.cs
+++ b/code/TheDiscDb.Core/SummaryFileParser.cs
@@ -97,6 +97,30 @@
                 {
                     disc.MainMovies.Add(item);
                 }
+                else if (item.Type.Equals("Other", StringComparison.OrdinalIgnoreCase))
+                {
+                    disc.Others.Add(item);
+                }
+                else if (item.Type.Equals("Interview", StringComparison.OrdinalIgnoreCase))
+                {
+                    disc.Interviews.Add(item);
+                }
+                else if (item.Type.Equals("Featurette", StringComparison.OrdinalIgnoreCase))
+                {
+                    disc.Featurettes.Add(item);
+                }
+                else if (item.Type.Equals("Scene", StringComparison.OrdinalIgnoreCase))
+                {
+                    disc.Scenes.Add(item);
+                }
+                else if (item.Type.Equals("Music", StringComparison.OrdinalIgnoreCase))
+                {
+                    disc.Musics.Add(item);
+                }
+                else if (item.Type.Equals("Short", StringComparison.OrdinalIgnoreCase))
+                {
+                    disc.Shorts.Add(item);
+                }
                 else
                 {
                     disc.Unknown.Add(item);

--- a/code/TheDiscDb.Data/Models/UserFileNameTemplate.cs
+++ b/code/TheDiscDb.Data/Models/UserFileNameTemplate.cs
@@ -22,7 +22,9 @@ public class UserFileNameTemplate
 
     /// <summary>
     /// The disc-item type this template applies to (e.g. "MainMovie",
-    /// "Episode", "Extra", "Trailer", "DeletedScene").
+    /// "Episode", "Extra", "Trailer", "DeletedScene", or one of the Extra
+    /// sub-categories: "Other", "Interview", "Featurette", "Scene", "Music",
+    /// "Short").
     /// </summary>
     [Required]
     [MaxLength(64)]

--- a/code/TheDiscDb.Naming/DefaultFileNameTemplates.cs
+++ b/code/TheDiscDb.Naming/DefaultFileNameTemplates.cs
@@ -16,6 +16,12 @@ public static class DefaultFileNameTemplates
     public const string Extra = "{description}.mkv";
     public const string Trailer = "{description}.mkv";
     public const string DeletedScene = "{description}.mkv";
+    public const string Other = "{description}.mkv";
+    public const string Interview = "{description}.mkv";
+    public const string Featurette = "{description}.mkv";
+    public const string Scene = "{description}.mkv";
+    public const string Music = "{description}.mkv";
+    public const string Short = "{description}.mkv";
 
     private static readonly Dictionary<string, string> Map =
         new(StringComparer.OrdinalIgnoreCase)
@@ -23,6 +29,12 @@ public static class DefaultFileNameTemplates
             [ItemTypeNames.MainMovie] = MainMovie,
             [ItemTypeNames.Episode] = Episode,
             [ItemTypeNames.Extra] = Extra,
+            [ItemTypeNames.Other] = Other,
+            [ItemTypeNames.Interview] = Interview,
+            [ItemTypeNames.Featurette] = Featurette,
+            [ItemTypeNames.Scene] = Scene,
+            [ItemTypeNames.Music] = Music,
+            [ItemTypeNames.Short] = Short,
             [ItemTypeNames.Trailer] = Trailer,
             [ItemTypeNames.DeletedScene] = DeletedScene,
         };
@@ -39,6 +51,12 @@ public static class DefaultFileNameTemplates
         ItemTypeNames.MainMovie,
         ItemTypeNames.Episode,
         ItemTypeNames.Extra,
+        ItemTypeNames.Other,
+        ItemTypeNames.Interview,
+        ItemTypeNames.Featurette,
+        ItemTypeNames.Scene,
+        ItemTypeNames.Music,
+        ItemTypeNames.Short,
         ItemTypeNames.Trailer,
         ItemTypeNames.DeletedScene,
     };

--- a/code/TheDiscDb.Naming/ItemTypeNames.cs
+++ b/code/TheDiscDb.Naming/ItemTypeNames.cs
@@ -1,5 +1,8 @@
 namespace TheDiscDb.Naming;
 
+using System;
+using System.Collections.Generic;
+
 /// <summary>
 /// Canonical string values used for the disc-item type ("MainMovie", etc.).
 /// Mirrors the values produced by <c>SummaryFileParser</c> and stored on
@@ -12,4 +15,39 @@ public static class ItemTypeNames
     public const string Extra = "Extra";
     public const string Trailer = "Trailer";
     public const string DeletedScene = "DeletedScene";
+
+    // Extra sub-categories. These behave the same as Extra during disc
+    // identification but allow contributors to label content more precisely.
+    public const string Other = "Other";
+    public const string Interview = "Interview";
+    public const string Featurette = "Featurette";
+    public const string Scene = "Scene";
+    public const string Music = "Music";
+    public const string Short = "Short";
+
+    /// <summary>
+    /// All type strings that should be treated as members of the "Extra" family.
+    /// Includes <see cref="Extra"/> itself plus the sub-categories.
+    /// </summary>
+    public static IReadOnlyList<string> ExtraTypes { get; } = new[]
+    {
+        Extra,
+        Other,
+        Interview,
+        Featurette,
+        Scene,
+        Music,
+        Short,
+    };
+
+    private static readonly HashSet<string> ExtraTypeSet =
+        new(ExtraTypes, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when <paramref name="type"/> is <see cref="Extra"/> or any
+    /// of its sub-categories. Use this instead of comparing directly to the
+    /// literal "Extra" string when the intent is "any extra-family item".
+    /// </summary>
+    public static bool IsExtra(string? type) =>
+        !string.IsNullOrEmpty(type) && ExtraTypeSet.Contains(type);
 }

--- a/code/TheDiscDb.Naming/ItemTypeNames.cs
+++ b/code/TheDiscDb.Naming/ItemTypeNames.cs
@@ -29,16 +29,31 @@ public static class ItemTypeNames
     /// All type strings that should be treated as members of the "Extra" family.
     /// Includes <see cref="Extra"/> itself plus the sub-categories.
     /// </summary>
-    public static IReadOnlyList<string> ExtraTypes { get; } = new[]
-    {
+    public static IReadOnlyList<string> ExtraTypes =>
+    [
         Extra,
         Other,
         Interview,
         Featurette,
         Scene,
         Music,
+        Short
+    ];
+
+    public static IReadOnlyList<string> AllTypes => 
+    [
+        MainMovie,
+        Episode,
+        Trailer,
+        DeletedScene,
+        Extra,
+        Interview,
+        Featurette,
+        Scene,
+        Music,
         Short,
-    };
+        Other
+    ];
 
     private static readonly HashSet<string> ExtraTypeSet =
         new(ExtraTypes, StringComparer.OrdinalIgnoreCase);

--- a/code/TheDiscDb.UnitTests/Client/NavigationExtensionsTests.cs
+++ b/code/TheDiscDb.UnitTests/Client/NavigationExtensionsTests.cs
@@ -247,6 +247,22 @@ public class NavigationExtensionsTests
     }
 
     [Test]
+    [Arguments("Other")]
+    [Arguments("Interview")]
+    [Arguments("Featurette")]
+    [Arguments("Scene")]
+    [Arguments("Music")]
+    [Arguments("Short")]
+    public async Task DiscFeatureDescription_ExtraSubType_RendersAsExtra(string type)
+    {
+        var singular = new DiscFeature { Type = type, Count = 1 };
+        var plural = new DiscFeature { Type = type, Count = 4 };
+
+        await Assert.That(singular.Description).IsEqualTo("1 extra");
+        await Assert.That(plural.Description).IsEqualTo("4 extras");
+    }
+
+    [Test]
     public async Task DiscFeatureDescription_NullType_ReturnsEmpty()
     {
         var feature = new DiscFeature { Type = null, Count = 1 };

--- a/code/TheDiscDb.UnitTests/Core/SummaryFileParserTests.cs
+++ b/code/TheDiscDb.UnitTests/Core/SummaryFileParserTests.cs
@@ -1,0 +1,68 @@
+using TheDiscDb;
+
+namespace TheDiscDb.UnitTests.Core;
+
+public class SummaryFileParserTests
+{
+    private static string MakeItem(string name, string type) =>
+        string.Join(System.Environment.NewLine, new[]
+        {
+            $"Name: {name}",
+            $"Source file name: {name}.m2ts",
+            "Duration: 0:10:00",
+            "Size: 1.0 GB",
+            "Segment map: 100",
+            $"Type: {type}",
+            $"File name: {name}.mkv",
+        });
+
+    [Test]
+    [Arguments("Other", "Others")]
+    [Arguments("Interview", "Interviews")]
+    [Arguments("Featurette", "Featurettes")]
+    [Arguments("Scene", "Scenes")]
+    [Arguments("Music", "Musics")]
+    [Arguments("Short", "Shorts")]
+    public async Task Categorize_ExtraSubType_RoutesToOwnBucket(string type, string bucketName)
+    {
+        var input = MakeItem("Title", type);
+
+        var disc = SummaryFileParser.ParseSingleDisc(input);
+
+        var bucket = typeof(TheDiscDb.ImportModels.DiscFile)
+            .GetProperty(bucketName)!
+            .GetValue(disc) as System.Collections.IEnumerable;
+
+        await Assert.That(bucket).IsNotNull();
+        await Assert.That(bucket!.Cast<object>().Count()).IsEqualTo(1);
+        await Assert.That(disc.Unknown).IsEmpty();
+        await Assert.That(disc.Extras).IsEmpty();
+    }
+
+    [Test]
+    public async Task Categorize_OriginalTypesStillRouted()
+    {
+        var input = string.Join(System.Environment.NewLine + System.Environment.NewLine, new[]
+        {
+            MakeItem("Movie",  "MainMovie"),
+            MakeItem("BTS",    "Extra"),
+            MakeItem("S01E01", "Episode"),
+            MakeItem("Promo",  "Trailer"),
+            MakeItem("Cut",    "DeletedScene"),
+        });
+
+        var disc = SummaryFileParser.ParseSingleDisc(input);
+
+        await Assert.That(disc.MainMovies).Count().IsEqualTo(1);
+        await Assert.That(disc.Extras).Count().IsEqualTo(1);
+        await Assert.That(disc.Episodes).Count().IsEqualTo(1);
+        await Assert.That(disc.Trailers).Count().IsEqualTo(1);
+        await Assert.That(disc.DeletedScenes).Count().IsEqualTo(1);
+        await Assert.That(disc.Others).IsEmpty();
+        await Assert.That(disc.Interviews).IsEmpty();
+        await Assert.That(disc.Featurettes).IsEmpty();
+        await Assert.That(disc.Scenes).IsEmpty();
+        await Assert.That(disc.Musics).IsEmpty();
+        await Assert.That(disc.Shorts).IsEmpty();
+    }
+}

--- a/code/TheDiscDb.UnitTests/Naming/DefaultFileNameTemplatesTests.cs
+++ b/code/TheDiscDb.UnitTests/Naming/DefaultFileNameTemplatesTests.cs
@@ -15,6 +15,20 @@ public class DefaultFileNameTemplatesTests
     }
 
     [Test]
+    [Arguments(ItemTypeNames.Other)]
+    [Arguments(ItemTypeNames.Interview)]
+    [Arguments(ItemTypeNames.Featurette)]
+    [Arguments(ItemTypeNames.Scene)]
+    [Arguments(ItemTypeNames.Music)]
+    [Arguments(ItemTypeNames.Short)]
+    public async Task KnownItemTypes_ContainsExtraSubTypes(string itemType)
+    {
+        await Assert.That(DefaultFileNameTemplates.KnownItemTypes).Contains(itemType);
+        await Assert.That(DefaultFileNameTemplates.IsKnownItemType(itemType)).IsTrue();
+        await Assert.That(DefaultFileNameTemplates.GetDefault(itemType)).IsEqualTo(DefaultFileNameTemplates.Extra);
+    }
+
+    [Test]
     public async Task IsKnownItemType_ReturnsTrueForKnown()
     {
         await Assert.That(DefaultFileNameTemplates.IsKnownItemType("MainMovie")).IsTrue();

--- a/code/TheDiscDb.UnitTests/Naming/ItemTypeNamesTests.cs
+++ b/code/TheDiscDb.UnitTests/Naming/ItemTypeNamesTests.cs
@@ -1,0 +1,59 @@
+using TheDiscDb.Naming;
+
+namespace TheDiscDb.UnitTests.Naming;
+
+public class ItemTypeNamesTests
+{
+    [Test]
+    [Arguments(ItemTypeNames.Extra)]
+    [Arguments(ItemTypeNames.Other)]
+    [Arguments(ItemTypeNames.Interview)]
+    [Arguments(ItemTypeNames.Featurette)]
+    [Arguments(ItemTypeNames.Scene)]
+    [Arguments(ItemTypeNames.Music)]
+    [Arguments(ItemTypeNames.Short)]
+    public async Task IsExtra_ReturnsTrueForExtraFamily(string type)
+    {
+        await Assert.That(ItemTypeNames.IsExtra(type)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("extra")]
+    [Arguments("EXTRA")]
+    [Arguments("interview")]
+    [Arguments("FEATURETTE")]
+    public async Task IsExtra_IsCaseInsensitive(string type)
+    {
+        await Assert.That(ItemTypeNames.IsExtra(type)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(ItemTypeNames.MainMovie)]
+    [Arguments(ItemTypeNames.Episode)]
+    [Arguments(ItemTypeNames.Trailer)]
+    [Arguments(ItemTypeNames.DeletedScene)]
+    [Arguments("Bogus")]
+    public async Task IsExtra_ReturnsFalseForNonExtra(string type)
+    {
+        await Assert.That(ItemTypeNames.IsExtra(type)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsExtra_NullOrEmpty_ReturnsFalse()
+    {
+        await Assert.That(ItemTypeNames.IsExtra(null)).IsFalse();
+        await Assert.That(ItemTypeNames.IsExtra(string.Empty)).IsFalse();
+    }
+
+    [Test]
+    public async Task ExtraTypes_ContainsExtraAndAllSubCategories()
+    {
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Extra);
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Other);
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Interview);
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Featurette);
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Scene);
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Music);
+        await Assert.That(ItemTypeNames.ExtraTypes).Contains(ItemTypeNames.Short);
+    }
+}

--- a/code/TheDiscDb/Components/Pages/Admin/DiscItemDetails.razor
+++ b/code/TheDiscDb/Components/Pages/Admin/DiscItemDetails.razor
@@ -25,7 +25,7 @@
 
             <div class="mb-3">
                 <label>Type</label>
-                <SfDropDownList TValue="string" TItem="string" DataSource="itemTypes" class="form-control" @bind-Value="Item.Type" Placeholder="Select type"></SfDropDownList>
+                <SfDropDownList TValue="string" TItem="string" DataSource="TheDiscDb.Naming.ItemTypeNames.AllTypes" class="form-control" @bind-Value="Item.Type" Placeholder="Select type"></SfDropDownList>
                 <ValidationMessage For="@(() => Item.Type)" />
             </div>
             <div class="mb-3">

--- a/code/TheDiscDb/Components/Pages/Admin/DiscItemDetails.razor.cs
+++ b/code/TheDiscDb/Components/Pages/Admin/DiscItemDetails.razor.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using TheDiscDb.Naming;
 using TheDiscDb.Web.Data;
 
 namespace TheDiscDb.Components.Pages.Admin;
@@ -29,8 +30,6 @@ public partial class DiscItemDetails : ComponentBase, IAsyncDisposable
     private UserContributionDisc? Disc { get; set; }
     private UserContributionDiscItem? Item { get; set; }
     private TheDiscDbUser? User { get; set; }
-
-    readonly string[] itemTypes = ["MainMovie", "Extra", "Episode", "DeletedScene", "Trailer", "Other", "Interview", "Featurette", "Scene", "Music", "Short"];
 
     protected override async Task OnInitializedAsync()
     {

--- a/code/TheDiscDb/Components/Pages/Admin/DiscItemDetails.razor.cs
+++ b/code/TheDiscDb/Components/Pages/Admin/DiscItemDetails.razor.cs
@@ -30,7 +30,7 @@ public partial class DiscItemDetails : ComponentBase, IAsyncDisposable
     private UserContributionDiscItem? Item { get; set; }
     private TheDiscDbUser? User { get; set; }
 
-    readonly string[] itemTypes = ["MainMovie", "Extra", "Episode", "DeletedScene", "Trailer"];
+    readonly string[] itemTypes = ["MainMovie", "Extra", "Episode", "DeletedScene", "Trailer", "Other", "Interview", "Featurette", "Scene", "Music", "Short"];
 
     protected override async Task OnInitializedAsync()
     {

--- a/code/TheDiscDb/ServerClipboardService.cs
+++ b/code/TheDiscDb/ServerClipboardService.cs
@@ -12,13 +12,13 @@ public class ServerClipboardService : IClipboardService
         this.jsRuntime = jsRuntime;
     }
 
-    public ValueTask<string> ReadTextAsync()
+    public ValueTask<string> ReadTextAsync(CancellationToken cancellationToken = default)
     {
-        return jsRuntime.InvokeAsync<string>("navigator.clipboard.readText");
+        return jsRuntime.InvokeAsync<string>("navigator.clipboard.readText", cancellationToken);
     }
 
-    public ValueTask WriteTextAsync(string text)
+    public ValueTask WriteTextAsync(string text, CancellationToken cancellationToken = default)
     {
-        return jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
+        return jsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text, cancellationToken);
     }
 }


### PR DESCRIPTION
Addresses #32 - more available types for disc items. All of the new types are treated the same as the 'Extra' type was previously.