### PR TITLE
Admin: don't allow reviewing a withdrawn edit suggestion

### DIFF
--- a/code/TheDiscDb.Data/Models/EditSuggestionStatusExtensions.cs
+++ b/code/TheDiscDb.Data/Models/EditSuggestionStatusExtensions.cs
@@ -1,0 +1,18 @@
+namespace TheDiscDb.Web.Data;
+
+public static class EditSuggestionStatusExtensions
+{
+    /// <summary>
+    /// True when an admin can still act on the suggestion (approve / reject /
+    /// resolve its changes). The terminal states — <see cref="EditSuggestionStatus.Draft"/>,
+    /// <see cref="EditSuggestionStatus.Approved"/>, <see cref="EditSuggestionStatus.Rejected"/>
+    /// and <see cref="EditSuggestionStatus.Withdrawn"/> — are not reviewable, even
+    /// though individual child changes may still carry a Pending status (e.g. a
+    /// user withdrew a suggestion before any change was actioned).
+    /// </summary>
+    public static bool IsReviewable(this EditSuggestionStatus status)
+        => status is EditSuggestionStatus.Pending
+            or EditSuggestionStatus.InReview
+            or EditSuggestionStatus.PartiallyApproved
+            or EditSuggestionStatus.Conflicted;
+}

--- a/code/TheDiscDb.UnitTests/Services/EditSuggestions/EditSuggestionReviewServiceTests.cs
+++ b/code/TheDiscDb.UnitTests/Services/EditSuggestions/EditSuggestionReviewServiceTests.cs
@@ -205,4 +205,44 @@ public class EditSuggestionReviewServiceTests
 
         await Assert.That(result).IsNull();
     }
+
+    [Test]
+    public async Task ApproveChangeAsync_ReturnsNull_WhenSuggestionWithdrawn()
+    {
+        var (db, reviewService, suggestion) = await SetupAsync();
+        var change = suggestion.Changes.First();
+
+        // User withdrew the suggestion; its change is still Pending.
+        var entity = await db.EditSuggestions.FirstAsync(s => s.Id == suggestion.Id);
+        entity.Status = EditSuggestionStatus.Withdrawn;
+        await db.SaveChangesAsync();
+
+        var result = await reviewService.ApproveChangeAsync(suggestion.Id, change.Id, "admin-1", null, CT);
+
+        await Assert.That(result).IsNull();
+
+        // Change must remain Pending and the release untouched.
+        var reloadedChange = await db.Set<EditSuggestionChange>().FirstAsync(c => c.Id == change.Id);
+        await Assert.That(reloadedChange.Status).IsEqualTo(EditSuggestionChangeStatus.Pending);
+        var release = await db.Releases.FirstAsync(r => r.Slug == "the-release");
+        await Assert.That(release.Title).IsEqualTo("Original Title");
+    }
+
+    [Test]
+    public async Task RejectChangeAsync_ReturnsNull_WhenSuggestionWithdrawn()
+    {
+        var (db, reviewService, suggestion) = await SetupAsync();
+        var change = suggestion.Changes.First();
+
+        var entity = await db.EditSuggestions.FirstAsync(s => s.Id == suggestion.Id);
+        entity.Status = EditSuggestionStatus.Withdrawn;
+        await db.SaveChangesAsync();
+
+        var result = await reviewService.RejectChangeAsync(suggestion.Id, change.Id, "admin-1", "no", CT);
+
+        await Assert.That(result).IsNull();
+
+        var reloadedChange = await db.Set<EditSuggestionChange>().FirstAsync(c => c.Id == change.Id);
+        await Assert.That(reloadedChange.Status).IsEqualTo(EditSuggestionChangeStatus.Pending);
+    }
 }

--- a/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor
+++ b/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor
@@ -46,7 +46,14 @@ else
         </dl>
     </section>
 
-    @if (suggestion.Status == EditSuggestionStatus.Pending || suggestion.Status == EditSuggestionStatus.InReview)
+    @if (!CanReview)
+    {
+        <div class="alert alert-secondary">
+            This suggestion is <strong>@suggestion.Status</strong> and can no longer be reviewed.
+        </div>
+    }
+
+    @if (CanReview && suggestion.Changes.Any(c => c.Status == EditSuggestionChangeStatus.Pending))
     {
         <div class="mb-3">
             <button class="btn btn-success" @onclick="ApproveAll" disabled="@isProcessing">Approve All Pending</button>
@@ -88,7 +95,7 @@ else
                     </div>
                 }
             </div>
-            @if (change.Status == EditSuggestionChangeStatus.Pending)
+            @if (CanReview && change.Status == EditSuggestionChangeStatus.Pending)
             {
                 <div class="card-footer">
                     <div class="d-flex gap-2 align-items-center">
@@ -106,7 +113,7 @@ else
                     </div>
                 </div>
             }
-            @if (change.Status == EditSuggestionChangeStatus.Conflicted)
+            @if (CanReview && change.Status == EditSuggestionChangeStatus.Conflicted)
             {
                 <div class="card-footer d-flex gap-2 align-items-center">
                     <input class="form-control form-control-sm" style="max-width: 300px;"

--- a/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor.cs
+++ b/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor.cs
@@ -233,6 +233,8 @@ public partial class EditSuggestionDetail : ComponentBase
     private bool HasRejectionReason(int changeId) =>
         rejectionReasons.TryGetValue(changeId, out var reason) && !string.IsNullOrWhiteSpace(reason);
 
+    private bool CanReview => suggestion is not null && suggestion.Status.IsReviewable();
+
     private static string FormatJson(string json)
     {
         try

--- a/code/TheDiscDb/Services/EditSuggestions/EditSuggestionReviewService.cs
+++ b/code/TheDiscDb/Services/EditSuggestions/EditSuggestionReviewService.cs
@@ -30,6 +30,11 @@ public sealed class EditSuggestionReviewService(
 
         var (suggestion, change) = loaded;
 
+        if (!suggestion.Status.IsReviewable())
+        {
+            return null;
+        }
+
         if (change.Status is not EditSuggestionChangeStatus.Pending)
         {
             return null;
@@ -87,6 +92,11 @@ public sealed class EditSuggestionReviewService(
 
         var (suggestion, change) = loaded;
 
+        if (!suggestion.Status.IsReviewable())
+        {
+            return null;
+        }
+
         if (change.Status is not EditSuggestionChangeStatus.Pending)
         {
             return null;
@@ -118,6 +128,11 @@ public sealed class EditSuggestionReviewService(
             return null;
         }
 
+        if (!suggestion.Status.IsReviewable())
+        {
+            return suggestion;
+        }
+
         foreach (var change in suggestion.Changes.Where(c => c.Status == EditSuggestionChangeStatus.Pending))
         {
             await ApproveChangeAsync(suggestionId, change.Id, adminUserId, adminNote: null, cancellationToken);
@@ -143,6 +158,11 @@ public sealed class EditSuggestionReviewService(
         }
 
         var (suggestion, change) = loaded;
+
+        if (!suggestion.Status.IsReviewable())
+        {
+            return null;
+        }
 
         if (change.Status is not EditSuggestionChangeStatus.Conflicted)
         {


### PR DESCRIPTION
## Problem
On an edit suggestion that the user has **withdrawn** (e.g. /admin/changes/1), the admin review page still showed Approve/Reject buttons and the change could be accepted or rejected.

Root cause: withdrawing a suggestion sets the **bundle** status to `Withdrawn` but leaves its child changes as `Pending`. Both the UI (per-change footer gated only on `change.Status == Pending`) and the review service (guarded only on the change status) ignored the parent suggestion status.

## Fix
Add `EditSuggestionStatus.IsReviewable()` — true only for `Pending`, `InReview`, `PartiallyApproved` and `Conflicted`; the terminal states `Draft`, `Approved`, `Rejected` and `Withdrawn` are not reviewable. Enforced at both layers:

- **EditSuggestionReviewService** — `ApproveChangeAsync` / `RejectChangeAsync` / `ResolveConflictAsync` / `ApproveAllPendingAsync` no-op when the suggestion isn't reviewable.
- **Admin EditSuggestionDetail page** — hides the per-change controls and the *Approve All Pending* button, and shows a notice that the suggestion can no longer be reviewed.

## Testing
- 573 unit tests pass, including 2 new cases asserting Approve/Reject return null and leave the change Pending / DB untouched when the suggestion is withdrawn.
- No DB/migration impact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
