### PR TITLE
Fix release date field rejecting valid dates in non-US locales

### DIFF
--- a/code/TheDiscDb.Client/Controls/ReleaseDateInput.razor.cs
+++ b/code/TheDiscDb.Client/Controls/ReleaseDateInput.razor.cs
@@ -10,7 +10,7 @@ public partial class ReleaseDateInput : ComponentBase
     public string Label { get; set; } = "Release Date";
 
     [Parameter]
-    public string Placeholder { get; set; } = "e.g. January 15, 2025 or 01-15-2025";
+    public string Placeholder { get; set; } = "e.g. January 15, 2025 or 2025-01-15";
 
     [Parameter]
     public DateTimeOffset? Value { get; set; }
@@ -28,7 +28,7 @@ public partial class ReleaseDateInput : ComponentBase
     {
         if (Value.HasValue && string.IsNullOrEmpty(dateText))
         {
-            dateText = Value.Value.ToString("MM-dd-yyyy");
+            dateText = Value.Value.ToString("yyyy-MM-dd");
         }
     }
 
@@ -47,7 +47,7 @@ public partial class ReleaseDateInput : ComponentBase
 
         if (DateTimeOffset.TryParseExact(input, "MMMM d, yyyy", null, System.Globalization.DateTimeStyles.None, out var parsedDate))
         {
-            dateText = parsedDate.ToString("MM-dd-yyyy");
+            dateText = parsedDate.ToString("yyyy-MM-dd");
         }
     }
 
@@ -67,9 +67,10 @@ public partial class ReleaseDateInput : ComponentBase
         }
 
         if (DateTimeOffset.TryParseExact(dateText, "MMMM d, yyyy", null, System.Globalization.DateTimeStyles.None, out var parsedDate)
-            || DateTimeOffset.TryParse(dateText, out parsedDate))
+            || DateTimeOffset.TryParseExact(dateText, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out parsedDate)
+            || DateTimeOffset.TryParse(dateText, System.Globalization.CultureInfo.InvariantCulture, out parsedDate))
         {
-            dateText = parsedDate.ToString("MM-dd-yyyy");
+            dateText = parsedDate.ToString("yyyy-MM-dd");
             await ValueChanged.InvokeAsync(parsedDate);
         }
         else


### PR DESCRIPTION
## Problem

In non-US locales (e.g. en-GB), the release date field's auto-populated value (e.g. \12-27-2010\) was shown as invalid. The root cause was twofold:

1. **Display format \MM-dd-yyyy\ is regionally ambiguous.** A user in a \dd-MM-yyyy\ locale sees the pre-filled value and can't tell if it's correct.
2. **\DateTimeOffset.TryParse\ used \CultureInfo.CurrentCulture\** (the browser locale in Blazor WASM). With \n-GB\, \12-27-2010\ is interpreted as day=12, month=**27** → invalid month → parse fails → validation error shown.

Closes TheDiscDb/data#362

## Fix

- Switch all display formatting from \MM-dd-yyyy\ to **\yyyy-MM-dd\** (ISO 8601) — unambiguous in every locale.
- Add an explicit \TryParseExact\ for \yyyy-MM-dd\ with \InvariantCulture\.
- Change the \TryParse\ fallback to use \InvariantCulture\ instead of the thread culture.