### PR TITLE
Model AACS Disc ID per pressing (ReleaseDisc) with conflict resolution

### DIFF
--- a/code/TheDiscDb.Client/Pages/DiscDetail.razor.cs
+++ b/code/TheDiscDb.Client/Pages/DiscDetail.razor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/code/TheDiscDb.Contributions/Contributions/ContributionDiscService.cs
+++ b/code/TheDiscDb.Contributions/Contributions/ContributionDiscService.cs
@@ -81,7 +81,8 @@ public sealed class ContributionDiscService(
         }
 
         return new ContributionDiscResult(
-            contribution.Id, disc.Id, encodedContributionId, encodedDiscId, disc.LogsUploaded, disc.LogUploadError);
+            contribution.Id, disc.Id, encodedContributionId, encodedDiscId, disc.LogsUploaded, disc.LogUploadError,
+            await IsGlobalDiscIdInUseElsewhereAsync(request.GlobalDiscId, cancellationToken));
     }
 
     public async Task<ContributionDiscResult?> AddDiscToContributionAsync(
@@ -158,7 +159,21 @@ public sealed class ContributionDiscService(
         }
 
         return new ContributionDiscResult(
-            contribution.Id, disc.Id, encodedContribution, encodedDiscId, disc.LogsUploaded, disc.LogUploadError);
+            contribution.Id, disc.Id, encodedContribution, encodedDiscId, disc.LogsUploaded, disc.LogUploadError,
+            await IsGlobalDiscIdInUseElsewhereAsync(request.GlobalDiscId, cancellationToken));
+    }
+
+    // A Disc ID identifies one physical pressing. Flag (do not block) when the submitted id is
+    // already assigned to a catalogue release-disc, so the contribution UI/admin can review whether
+    // it's the same pressing recorded twice or a mis-scan.
+    private async Task<bool> IsGlobalDiscIdInUseElsewhereAsync(string? globalDiscId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(globalDiscId))
+        {
+            return false;
+        }
+
+        return await database.ReleaseDiscs.AnyAsync(rd => rd.GlobalDiscId == globalDiscId, cancellationToken);
     }
 
     // Mirrors the web SaveDiscLogsInternal: normalize to CRLF, validate as MakeMKV, then store at

--- a/code/TheDiscDb.Contributions/Contributions/IContributionDiscService.cs
+++ b/code/TheDiscDb.Contributions/Contributions/IContributionDiscService.cs
@@ -50,7 +50,8 @@ public sealed record ContributionDiscResult(
     string EncodedContributionId,
     string EncodedDiscId,
     bool LogsUploaded,
-    string? LogUploadError);
+    string? LogUploadError,
+    bool GlobalDiscIdCollision = false);
 
 public interface IContributionDiscService
 {

--- a/code/TheDiscDb.Contributions/DiscId/DiscIdBackfillService.cs
+++ b/code/TheDiscDb.Contributions/DiscId/DiscIdBackfillService.cs
@@ -20,7 +20,7 @@ public enum AttachDiscIdOutcome
     /// <summary>The disc already carried this exact Disc ID; nothing to do.</summary>
     AlreadyRecorded,
 
-    /// <summary>The disc already has a different Disc ID; a pending change was filed for review, DB untouched.</summary>
+    /// <summary>The Disc ID belongs to a different release-disc, or this disc already has a different id; a pending change was filed for review, DB untouched.</summary>
     Conflict,
 
     /// <summary>No disc in the database matched the submitted content-hash / identity.</summary>
@@ -113,7 +113,7 @@ public sealed class DiscIdBackfillService(
                 if (altDisc?.Disc is null)
                 {
                     // Not the target, and not otherwise known -> genuine mismatch.
-                    return BuildResult(AttachDiscIdOutcome.Mismatch, contentHash, targetDisc, globalDiscId, targetDisc.Disc.GlobalDiscId);
+                    return BuildResult(AttachDiscIdOutcome.Mismatch, contentHash, targetDisc, globalDiscId, targetDisc.GlobalDiscId);
                 }
 
                 releaseDisc = altDisc;
@@ -137,8 +137,10 @@ public sealed class DiscIdBackfillService(
         return await ApplyAsync(userId, contentHash, globalDiscId, releaseDisc, matchedDifferentDisc, cancellationToken);
     }
 
-    // Applies the Disc ID to a resolved disc: idempotent no-op when already recorded, a pending
-    // (un-applied) change on conflict, or an auto-approved change + immediate write on a clean add.
+    // Applies the Disc ID to a resolved release-disc: idempotent no-op when it already carries the
+    // id; a pending (un-applied) conflict change when the id belongs to a *different* release-disc
+    // (cross-pressing) or this disc already carries a *different* id (same-release re-press);
+    // otherwise an auto-approved change + immediate write.
     private async Task<AttachDiscIdResult> ApplyAsync(
         string userId,
         string contentHash,
@@ -159,35 +161,48 @@ public sealed class DiscIdBackfillService(
             parentMediaSlug, parentBoxsetSlug, parentMediaType, parentReleaseSlug, snapshot.DiscSlug, snapshot.DiscIndex,
             globalDiscId, existingGlobalDiscId, matchedDifferentDisc);
 
-        var current = releaseDisc.Disc!.GlobalDiscId;
-
-        // Already carries this exact Disc ID -> idempotent no-op.
-        if (string.Equals(current, globalDiscId, StringComparison.OrdinalIgnoreCase))
-        {
-            return Result(AttachDiscIdOutcome.AlreadyRecorded, current);
-        }
-
-        // Only GlobalDiscId changes (all other fields equal the snapshot, so add-only applies just the id).
         var proposed = snapshot with { GlobalDiscId = globalDiscId };
         var proposedJson = JsonSerializer.Serialize(proposed, JsonOptions);
         var snapshotJson = JsonSerializer.Serialize(snapshot, JsonOptions);
 
-        // Conflict: a different Disc ID already exists -> file a pending change with a note, do NOT touch the DB.
-        if (!string.IsNullOrEmpty(current))
+        // Who (if anyone) already stores this exact id? The id is unique across release-discs.
+        var owner = await database.Set<ReleaseDisc>()
+            .Where(rd => rd.GlobalDiscId == globalDiscId)
+            .Select(rd => new { rd.Id, rd.DiscId })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (owner is not null)
         {
-            var note = $"Disc ID conflict: submitted {globalDiscId} but the disc already has {current}. Possible re-press/variant — needs review.";
-            var conflictSuggestion = await editSuggestionService.SubmitAsync(
-                userId,
-                EditSuggestionSource.GraphQL,
-                note,
-                new List<SubmitChangeInput> { new(DiscFieldsUpdate.Key, proposedJson, snapshotJson) },
-                cancellationToken);
+            // Stored on this release-disc, or on a sibling sharing the same canonical disc (same
+            // content = same pressing): already recorded — the read-time fallback surfaces it, and
+            // storing it again would violate the unique index. Nothing to do.
+            if (owner.DiscId == releaseDisc.DiscId)
+            {
+                return Result(AttachDiscIdOutcome.AlreadyRecorded, globalDiscId);
+            }
 
-            var conflictChange = conflictSuggestion.Changes.First();
-            conflictChange.ConflictReason = note;
-            await database.SaveChangesAsync(cancellationToken);
+            // Stored on a release-disc of a *different* canonical disc → the same id maps to two
+            // different contents; needs review.
+            var crossNote = $"Disc ID conflict: submitted {globalDiscId} is already assigned to a different disc (different content). Needs review.";
+            await FileConflictAsync(userId, crossNote, proposedJson, snapshotJson, cancellationToken);
+            return Result(AttachDiscIdOutcome.Conflict, globalDiscId);
+        }
 
-            return Result(AttachDiscIdOutcome.Conflict, current);
+        // The id isn't stored anywhere yet. Determine this pressing's effective id (its own, or the
+        // single id shared by siblings of the same canonical disc).
+        var siblingIds = await database.Set<ReleaseDisc>()
+            .Where(rd => rd.DiscId == releaseDisc.DiscId)
+            .Select(rd => rd.GlobalDiscId)
+            .ToListAsync(cancellationToken);
+        var effective = ReleaseDiscExtensions.EffectiveGlobalDiscId(siblingIds);
+
+        // Divergence: this pressing already resolves to a different id (its own or a shared sibling
+        // id). A different submission is a possible re-press / mis-scan → review, DB untouched.
+        if (!string.IsNullOrEmpty(effective))
+        {
+            var note = $"Disc ID conflict: this disc already has {effective} but {globalDiscId} was submitted. Possible re-press/variant — needs review.";
+            await FileConflictAsync(userId, note, proposedJson, snapshotJson, cancellationToken);
+            return Result(AttachDiscIdOutcome.Conflict, effective);
         }
 
         // Clean add: submit + auto-approve so the DB is written now and the change is Applied for /data sync.
@@ -202,12 +217,11 @@ public sealed class DiscIdBackfillService(
         var appliedChange = await reviewService.ApproveChangeAsync(
             suggestion.Id, changeId, userId, adminNote: "Auto-approved add-only Disc ID backfill", cancellationToken);
 
-        // Confirm the Disc ID actually persisted before reporting success. ReleaseDisc.GlobalDiscId
-        // is a passthrough to the canonical Disc; if that navigation wasn't loaded during apply the
-        // write would silently no-op, so we verify against the database rather than trust the status.
+        // Confirm the id persisted (the natural-key resolution during apply must have hit this
+        // release-disc) before reporting success.
         var persisted = await database.Set<ReleaseDisc>()
             .Where(rd => rd.Id == releaseDisc.Id)
-            .Select(rd => rd.Disc!.GlobalDiscId)
+            .Select(rd => rd.GlobalDiscId)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (appliedChange?.Status != EditSuggestionChangeStatus.Applied
@@ -218,6 +232,23 @@ public sealed class DiscIdBackfillService(
         }
 
         return Result(AttachDiscIdOutcome.Applied, null);
+    }
+
+    // Files a pending (un-applied) change carrying the conflict note for admin review, leaving the
+    // database untouched.
+    private async Task FileConflictAsync(
+        string userId, string note, string proposedJson, string snapshotJson, CancellationToken cancellationToken)
+    {
+        var conflictSuggestion = await editSuggestionService.SubmitAsync(
+            userId,
+            EditSuggestionSource.GraphQL,
+            note,
+            new List<SubmitChangeInput> { new(DiscFieldsUpdate.Key, proposedJson, snapshotJson) },
+            cancellationToken);
+
+        var conflictChange = conflictSuggestion.Changes.First();
+        conflictChange.ConflictReason = note;
+        await database.SaveChangesAsync(cancellationToken);
     }
 
     // Builds a terminal (non-applying) result carrying the given disc's identity for display.
@@ -242,7 +273,7 @@ public sealed class DiscIdBackfillService(
 
     private IQueryable<ReleaseDisc> BaseQuery()
         => database.Set<ReleaseDisc>()
-            .Include(rd => rd.Disc)
+            .Include(rd => rd.Disc!)
             .Include(rd => rd.Release!).ThenInclude(r => r.MediaItem)
             .Include(rd => rd.Release!).ThenInclude(r => r.Boxset);
 

--- a/code/TheDiscDb.Contributions/EditSuggestions/DiscIdConflictContext.cs
+++ b/code/TheDiscDb.Contributions/EditSuggestions/DiscIdConflictContext.cs
@@ -1,0 +1,34 @@
+namespace TheDiscDb.Services.EditSuggestions;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// A release-disc that shares the conflicted disc's content hash and is therefore a candidate
+/// destination for the submitted Disc ID. Presented to an admin resolving a Disc ID conflict.
+/// Only item (media-item) releases are candidates — boxset releases inherit their disc (and its
+/// id) from the item release they were copied from, so they never independently own an AACS id.
+/// </summary>
+public sealed record DiscIdConflictCandidate(
+    int ReleaseDiscId,
+    string? MediaItemSlug,
+    string ReleaseSlug,
+    string? DiscSlug,
+    int DiscIndex,
+    string? ReleaseTitle,
+    string? MediaTitle,
+    string? CurrentGlobalDiscId);
+
+/// <summary>
+/// Everything an admin needs to resolve a conflicted <c>disc.fields.update</c> Disc ID change:
+/// the submitted id, the id the target disc currently carries, and the other release-discs that
+/// share the same content (candidate homes for the submitted id — typically a re-pressed sibling
+/// edition that currently has no id).
+/// </summary>
+public sealed record DiscIdConflictContext(
+    int SuggestionId,
+    int ChangeId,
+    string SubmittedGlobalDiscId,
+    string? ContentHash,
+    string TargetKey,
+    string? TargetCurrentGlobalDiscId,
+    IReadOnlyList<DiscIdConflictCandidate> Candidates);

--- a/code/TheDiscDb.Contributions/EditSuggestions/EditSuggestionReviewService.cs
+++ b/code/TheDiscDb.Contributions/EditSuggestions/EditSuggestionReviewService.cs
@@ -1,11 +1,15 @@
 namespace TheDiscDb.Services.EditSuggestions;
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TheDiscDb.Data.Changes;
+using TheDiscDb.Data.Changes.DiscFields;
+using TheDiscDb.InputModels;
 using TheDiscDb.Web.Data;
 
 public sealed class EditSuggestionReviewService(
@@ -15,6 +19,8 @@ public sealed class EditSuggestionReviewService(
     IEditSuggestionNotificationService? notifications = null,
     IEditSuggestionRecipientResolver? recipients = null) : IEditSuggestionReviewService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     public async Task<EditSuggestionChange?> ApproveChangeAsync(
         int suggestionId,
         int changeId,
@@ -97,7 +103,8 @@ public sealed class EditSuggestionReviewService(
             return null;
         }
 
-        if (change.Status is not EditSuggestionChangeStatus.Pending)
+        if (change.Status is not EditSuggestionChangeStatus.Pending
+            and not EditSuggestionChangeStatus.Conflicted)
         {
             return null;
         }
@@ -214,6 +221,327 @@ public sealed class EditSuggestionReviewService(
             suggestionId, changeId, adminUserId,
             EditSuggestionChangeStatus.Conflicted, EditSuggestionChangeStatus.Applied,
             change.AdminNote, cancellationToken);
+
+        await RefreshBundleStatusAsync(suggestion, adminUserId, cancellationToken);
+        return change;
+    }
+
+    public async Task<DiscIdConflictContext?> GetDiscIdConflictContextAsync(
+        int suggestionId,
+        int changeId,
+        CancellationToken cancellationToken = default)
+    {
+        var loaded = await LoadChangeAsync(suggestionId, changeId, cancellationToken);
+        if (loaded is null || loaded.Change.Type != DiscFieldsUpdate.Key)
+        {
+            return null;
+        }
+
+        var change = loaded.Change;
+        var proposed = JsonSerializer.Deserialize<DiscFieldsDetails>(change.ProposedJson, JsonOptions);
+        if (proposed is null || string.IsNullOrEmpty(proposed.GlobalDiscId))
+        {
+            return null;
+        }
+
+        var contentHash = proposed.ContentHash;
+
+        // The target disc's current stored id (what it "already has").
+        var targetDisc = await DiscFieldsUpdate.ResolveDiscAsync(database, proposed, cancellationToken);
+
+        // Candidate destinations: item (media-item) release-discs whose canonical disc shares this
+        // content hash. Boxset releases are excluded — a boxset's disc is copied from the item
+        // release it references (an "existing disc"), so it inherits that pressing's id via the
+        // read-time fallback and never independently owns an AACS id. Attributing a distinct id to a
+        // boxset release-disc would contradict that "same disc" relationship.
+        var candidates = new List<DiscIdConflictCandidate>();
+        if (!string.IsNullOrEmpty(contentHash))
+        {
+            var rows = await database.Set<ReleaseDisc>()
+                .AsNoTracking()
+                .Where(rd => rd.Disc != null && rd.Disc.ContentHash == contentHash && rd.Release!.Boxset == null)
+                .Select(rd => new
+                {
+                    rd.Id,
+                    rd.Slug,
+                    rd.Index,
+                    rd.GlobalDiscId,
+                    ReleaseSlug = rd.Release!.Slug,
+                    ReleaseTitle = rd.Release.Title,
+                    MediaItemSlug = rd.Release.MediaItem != null ? rd.Release.MediaItem.Slug : null,
+                    MediaTitle = rd.Release.MediaItem != null ? rd.Release.MediaItem.Title : null,
+                })
+                .ToListAsync(cancellationToken);
+
+            candidates.AddRange(rows.Select(r => new DiscIdConflictCandidate(
+                r.Id, r.MediaItemSlug, r.ReleaseSlug ?? string.Empty,
+                r.Slug, r.Index, r.ReleaseTitle, r.MediaTitle, r.GlobalDiscId)));
+        }
+
+        return new DiscIdConflictContext(
+            suggestionId,
+            changeId,
+            proposed.GlobalDiscId,
+            contentHash,
+            proposed.TargetEntityKey,
+            targetDisc?.GlobalDiscId,
+            candidates);
+    }
+
+    public async Task<EditSuggestionChange?> AttributeDiscIdAsync(
+        int suggestionId,
+        int changeId,
+        int destinationReleaseDiscId,
+        string adminUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var loaded = await LoadChangeAsync(suggestionId, changeId, cancellationToken);
+        if (loaded is null)
+        {
+            return null;
+        }
+
+        var (suggestion, change) = loaded;
+        if (!suggestion.Status.IsReviewable() || change.Type != DiscFieldsUpdate.Key)
+        {
+            return null;
+        }
+
+        var proposed = JsonSerializer.Deserialize<DiscFieldsDetails>(change.ProposedJson, JsonOptions);
+        if (proposed is null || string.IsNullOrEmpty(proposed.GlobalDiscId))
+        {
+            return null;
+        }
+
+        var submittedId = proposed.GlobalDiscId;
+
+        // Resolve the chosen destination release-disc and its natural key.
+        var destination = await database.Set<ReleaseDisc>()
+            .Include(rd => rd.Disc)
+            .Include(rd => rd.Release!).ThenInclude(r => r.MediaItem)
+            .Include(rd => rd.Release!).ThenInclude(r => r.Boxset)
+            .FirstOrDefaultAsync(rd => rd.Id == destinationReleaseDiscId, cancellationToken);
+
+        if (destination?.Disc is null || destination.Release is null)
+        {
+            return null;
+        }
+
+        // Boxset release-discs inherit their disc (and its id) from the item release they were
+        // copied from, so they can't independently own an AACS id. Refuse to attribute to one even
+        // if a stale/hand-crafted request supplies it (the UI already excludes them as candidates).
+        if (destination.Release.Boxset != null)
+        {
+            change.Status = EditSuggestionChangeStatus.Conflicted;
+            change.ConflictReason = $"Destination release-disc belongs to a boxset, which inherits its disc from an item release — refusing to attribute Disc ID {submittedId}.";
+            await database.SaveChangesAsync(cancellationToken);
+            return change;
+        }
+
+        // Safety: only attribute the id to a disc that actually shares the submitted disc's content.
+        if (!string.IsNullOrEmpty(proposed.ContentHash)
+            && !string.Equals(destination.Disc.ContentHash, proposed.ContentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            change.Status = EditSuggestionChangeStatus.Conflicted;
+            change.ConflictReason = $"Destination release-disc content hash does not match the submitted disc — refusing to attribute Disc ID {submittedId}.";
+            await database.SaveChangesAsync(cancellationToken);
+            return change;
+        }
+
+        var mediaItemSlug = destination.Release.MediaItem?.Slug;
+        var releaseSlug = destination.Release.Slug ?? string.Empty;
+
+        // Retarget the conflicted change to the destination release-disc, then apply it there so it
+        // also syncs to /data with the correct target. The original release keeps its own id.
+        var snapshot = DiscFieldsUpdate.SnapshotFrom(destination, mediaItemSlug, boxsetSlug: null, releaseSlug);
+        var retargeted = snapshot with { GlobalDiscId = submittedId };
+
+        var originalTargetKey = proposed.TargetEntityKey;
+        change.ProposedJson = JsonSerializer.Serialize(retargeted, JsonOptions);
+        change.OriginalSnapshotJson = JsonSerializer.Serialize(snapshot, JsonOptions);
+
+        var oldStatus = change.Status;
+        var note = $"Attributed Disc ID {submittedId} to '{retargeted.TargetEntityKey}' (originally submitted for '{originalTargetKey}').";
+
+        var changeInstance = changeFactory.Create(change.Type, change.ProposedJson);
+        var validation = await changeInstance.ValidateAsync(database, change.OriginalSnapshotJson, cancellationToken);
+        if (validation.IsConflict)
+        {
+            change.Status = EditSuggestionChangeStatus.Conflicted;
+            change.ConflictReason = validation.ConflictReason;
+            change.AdminNote = note;
+            await database.SaveChangesAsync(cancellationToken);
+            await RefreshBundleStatusAsync(suggestion, adminUserId, cancellationToken);
+            return change;
+        }
+
+        var applyContext = new ChangeApplyContext(adminUserId, suggestionId, changeId, change.OriginalSnapshotJson);
+        await changeInstance.ApplyAsync(database, applyContext, cancellationToken);
+
+        change.Status = EditSuggestionChangeStatus.Applied;
+        change.ConflictReason = null;
+        change.AppliedAt = DateTimeOffset.UtcNow;
+        change.AppliedByUserId = adminUserId;
+        change.AdminNote = note;
+        await database.SaveChangesAsync(cancellationToken);
+
+        await historyService.RecordChangeStatusChangedAsync(
+            suggestionId, changeId, adminUserId, oldStatus, change.Status, note, cancellationToken);
+
+        await RefreshBundleStatusAsync(suggestion, adminUserId, cancellationToken);
+        return change;
+    }
+
+    public async Task<EditSuggestionChange?> SwapDiscIdAsync(
+        int suggestionId,
+        int changeId,
+        int secondaryReleaseDiscId,
+        string adminUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var loaded = await LoadChangeAsync(suggestionId, changeId, cancellationToken);
+        if (loaded is null)
+        {
+            return null;
+        }
+
+        var (suggestion, change) = loaded;
+        if (!suggestion.Status.IsReviewable() || change.Type != DiscFieldsUpdate.Key)
+        {
+            return null;
+        }
+
+        var proposed = JsonSerializer.Deserialize<DiscFieldsDetails>(change.ProposedJson, JsonOptions);
+        if (proposed is null || string.IsNullOrEmpty(proposed.GlobalDiscId))
+        {
+            return null;
+        }
+
+        var submittedId = proposed.GlobalDiscId; // the id being added (Y)
+
+        // Primary = the disc the conflicted change targets — the one that already carries an id (X).
+        var primary = await DiscFieldsUpdate.ResolveDiscAsync(database, proposed, cancellationToken);
+        if (primary?.Disc is null || primary.Release is null)
+        {
+            return null;
+        }
+
+        // Secondary = the sibling chosen to receive the primary's displaced id.
+        var secondary = await database.Set<ReleaseDisc>()
+            .Include(rd => rd.Disc)
+            .Include(rd => rd.Release!).ThenInclude(r => r.MediaItem)
+            .Include(rd => rd.Release!).ThenInclude(r => r.Boxset)
+            .FirstOrDefaultAsync(rd => rd.Id == secondaryReleaseDiscId, cancellationToken);
+        if (secondary?.Disc is null || secondary.Release is null)
+        {
+            return null;
+        }
+
+        async Task<EditSuggestionChange> RejectAsync(string reason)
+        {
+            change.Status = EditSuggestionChangeStatus.Conflicted;
+            change.ConflictReason = reason;
+            await database.SaveChangesAsync(cancellationToken);
+            return change;
+        }
+
+        var displacedId = primary.GlobalDiscId; // the primary's current id (X)
+
+        if (secondary.Id == primary.Id)
+        {
+            return await RejectAsync("Swap needs a different sibling release-disc to receive the displaced Disc ID.");
+        }
+
+        if (string.IsNullOrEmpty(displacedId))
+        {
+            return await RejectAsync("Swap requires the target disc to already have a Disc ID to displace; it has none — attribute the submitted id instead.");
+        }
+
+        if (secondary.Release.Boxset != null)
+        {
+            return await RejectAsync($"Destination release-disc belongs to a boxset, which inherits its disc from an item release — refusing to move Disc ID {displacedId} to it.");
+        }
+
+        if (!string.IsNullOrEmpty(secondary.GlobalDiscId))
+        {
+            return await RejectAsync($"Destination release-disc already has Disc ID {secondary.GlobalDiscId}; a swap only fills an empty sibling.");
+        }
+
+        // Both pressings must be the same physical content (same canonical disc / content hash).
+        if (secondary.DiscId != primary.DiscId
+            && !string.Equals(secondary.Disc.ContentHash, primary.Disc.ContentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            return await RejectAsync("Destination release-disc is a different disc (content hash mismatch) — refusing to swap Disc IDs across unrelated discs.");
+        }
+
+        // The submitted id must be free (or already on the primary — a no-op). Reject when a THIRD
+        // release-disc owns it.
+        var submittedOwnerId = await database.ReleaseDiscs
+            .Where(rd => rd.GlobalDiscId == submittedId)
+            .Select(rd => (int?)rd.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (submittedOwnerId is not null && submittedOwnerId != primary.Id)
+        {
+            return await RejectAsync($"Disc ID {submittedId} is already assigned to a different release-disc — cannot swap it onto this pressing.");
+        }
+
+        // Capture pre-swap snapshots (drive the /data sync): primary carries X, secondary carries none.
+        var primarySnapshot = DiscFieldsUpdate.SnapshotFrom(
+            primary, proposed.MediaItemSlug, proposed.BoxsetSlug, proposed.ReleaseSlug);
+        var secondaryMediaSlug = secondary.Release.MediaItem?.Slug;
+        var secondaryReleaseSlug = secondary.Release.Slug ?? string.Empty;
+        var secondarySnapshot = DiscFieldsUpdate.SnapshotFrom(
+            secondary, secondaryMediaSlug, boxsetSlug: null, secondaryReleaseSlug);
+
+        // Perform the swap one row at a time so the unique filtered index on GlobalDiscId is never
+        // transiently violated: free X off the primary first, land it on the secondary, then add Y.
+        primary.GlobalDiscId = null;
+        await database.SaveChangesAsync(cancellationToken);
+        secondary.GlobalDiscId = displacedId;
+        await database.SaveChangesAsync(cancellationToken);
+        primary.GlobalDiscId = submittedId;
+        await database.SaveChangesAsync(cancellationToken);
+
+        var oldStatus = change.Status;
+
+        // Retarget the conflicted change to the primary as an OVERWRITE X -> Y. The snapshot records
+        // X as the expected pre-image, which is what authorises the tools file applier to overwrite
+        // (its GlobalDiscId write is otherwise strictly add-only).
+        var primaryProposed = primarySnapshot with { GlobalDiscId = submittedId };
+        var primaryNote = $"Swapped Disc IDs: assigned {submittedId} to '{primaryProposed.TargetEntityKey}' and moved its previous id {displacedId} to '{secondarySnapshot.TargetEntityKey}'.";
+        change.OriginalSnapshotJson = JsonSerializer.Serialize(primarySnapshot, JsonOptions);
+        change.ProposedJson = JsonSerializer.Serialize(primaryProposed, JsonOptions);
+        change.Status = EditSuggestionChangeStatus.Applied;
+        change.ConflictReason = null;
+        change.AppliedAt = DateTimeOffset.UtcNow;
+        change.AppliedByUserId = adminUserId;
+        change.SyncedToFilesAt = null;
+        change.AdminNote = primaryNote;
+
+        // Add a sibling change that records the displaced id (X) landing on the secondary — a normal
+        // add-only write for its /data file.
+        var secondaryProposed = secondarySnapshot with { GlobalDiscId = displacedId };
+        var nextOrdinal = suggestion.Changes.Count == 0 ? 0 : suggestion.Changes.Max(c => c.Ordinal) + 1;
+        var secondaryChange = new EditSuggestionChange
+        {
+            SuggestionId = suggestion.Id,
+            Suggestion = suggestion,
+            Ordinal = nextOrdinal,
+            Type = DiscFieldsUpdate.Key,
+            OriginalSnapshotJson = JsonSerializer.Serialize(secondarySnapshot, JsonOptions),
+            ProposedJson = JsonSerializer.Serialize(secondaryProposed, JsonOptions),
+            Status = EditSuggestionChangeStatus.Applied,
+            AppliedAt = DateTimeOffset.UtcNow,
+            AppliedByUserId = adminUserId,
+            AdminNote = $"Received Disc ID {displacedId} displaced from '{primaryProposed.TargetEntityKey}' during a swap resolution.",
+        };
+        suggestion.Changes.Add(secondaryChange);
+        database.EditSuggestionChanges.Add(secondaryChange);
+
+        await database.SaveChangesAsync(cancellationToken);
+
+        await historyService.RecordChangeStatusChangedAsync(
+            suggestionId, change.Id, adminUserId, oldStatus, change.Status, primaryNote, cancellationToken);
 
         await RefreshBundleStatusAsync(suggestion, adminUserId, cancellationToken);
         return change;

--- a/code/TheDiscDb.Contributions/EditSuggestions/IEditSuggestionReviewService.cs
+++ b/code/TheDiscDb.Contributions/EditSuggestions/IEditSuggestionReviewService.cs
@@ -54,4 +54,47 @@ public interface IEditSuggestionReviewService
         string adminUserId,
         string resolution,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Builds the context for resolving a conflicted <c>disc.fields.update</c> Disc ID change:
+    /// the submitted id, the target disc's current id, and the release-discs sharing the same
+    /// content hash (candidate destinations). Returns null when the change isn't a Disc ID
+    /// conflict.
+    /// </summary>
+    Task<DiscIdConflictContext?> GetDiscIdConflictContextAsync(
+        int suggestionId,
+        int changeId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a Disc ID conflict by attributing the submitted Disc ID to a specific release-disc
+    /// (the correct edition/pressing — often a re-pressed sibling that currently has no id). The
+    /// conflicted change is retargeted to that release-disc and applied, so it also syncs to
+    /// <c>/data</c>. Returns the updated change; if the destination still can't accept the id
+    /// (already has a different one, or the id is taken elsewhere) the change stays
+    /// <see cref="EditSuggestionChangeStatus.Conflicted"/> with the reason.
+    /// </summary>
+    Task<EditSuggestionChange?> AttributeDiscIdAsync(
+        int suggestionId,
+        int changeId,
+        int destinationReleaseDiscId,
+        string adminUserId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a Disc ID conflict by <b>swapping</b>: the submitted id is assigned to the conflict
+    /// target (the release-disc that already carries an id), and that target's displaced id is moved
+    /// to a chosen empty sibling. Use when the original assignment was mis-attributed — the new id is
+    /// the target's true id and the old id really belongs to the sibling. Overwrites the target's id
+    /// (the only resolution that does), and records both reassignments as applied changes so they
+    /// sync to <c>/data</c>. Returns the updated (primary) change; stays
+    /// <see cref="EditSuggestionChangeStatus.Conflicted"/> with a reason if the swap isn't valid
+    /// (sibling occupied, is a boxset, different disc, or the submitted id is taken elsewhere).
+    /// </summary>
+    Task<EditSuggestionChange?> SwapDiscIdAsync(
+        int suggestionId,
+        int changeId,
+        int secondaryReleaseDiscId,
+        string adminUserId,
+        CancellationToken cancellationToken = default);
 }

--- a/code/TheDiscDb.Core/ImportModels/DiscReferenceFile.cs
+++ b/code/TheDiscDb.Core/ImportModels/DiscReferenceFile.cs
@@ -9,4 +9,12 @@ public class DiscReferenceFile
 
     [JsonPropertyName("disc")]
     public string Disc { get; set; } = string.Empty;
+
+    /// <summary>
+    /// This referencing release's own pressing Disc ID (AACS Disc ID / DVDDiscID). Optional and
+    /// distinct from the referenced disc's id: the two releases share content but are different
+    /// physical pressings. Null when unknown.
+    /// </summary>
+    [JsonPropertyName("globalDiscId")]
+    public string? GlobalDiscId { get; set; }
 }

--- a/code/TheDiscDb.Core/InputModels/Disc.cs
+++ b/code/TheDiscDb.Core/InputModels/Disc.cs
@@ -27,11 +27,16 @@ namespace TheDiscDb.InputModels
         public string? ContentHash { get; set; }
 
         /// <summary>
-        /// Globally-stable, per-pressing disc identifier. For Blu-ray/UHD this is the AACS
-        /// Disc ID (SHA-1 of AACS/Unit_Key_RO.inf); for DVD it is the libdvdread DVDDiscID
-        /// (MD5 of the IFO files). The disc <see cref="Format"/> disambiguates which algorithm
-        /// produced it. Add-only and optional (absent on MKV-only rips).
+        /// Transient carrier for the pressing's globally-stable Disc ID as read from a
+        /// <c>disc*.json</c> (or overridden from a <c>.ref</c>). This is NOT a column on the shared
+        /// canonical disc: the id identifies a physical pressing, so import copies it onto the
+        /// owning <see cref="ReleaseDisc.GlobalDiscId"/> (the same pattern as
+        /// <see cref="Index"/>/<see cref="Slug"/>/<see cref="Name"/>). Serialized under the
+        /// PascalCase <c>GlobalDiscId</c> key like the rest of <c>disc*.json</c> (no naming policy),
+        /// so it needs no <c>JsonPropertyName</c>.
         /// </summary>
+        [NotMapped]
+        [HotChocolate.GraphQLIgnore]
         public string? GlobalDiscId { get; set; }
 
         [HotChocolate.Data.UseFiltering]

--- a/code/TheDiscDb.Core/InputModels/ReleaseDisc.cs
+++ b/code/TheDiscDb.Core/InputModels/ReleaseDisc.cs
@@ -3,6 +3,7 @@ namespace TheDiscDb.InputModels;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 
 public class ReleaseDisc : IDisc
 {
@@ -51,21 +52,77 @@ public class ReleaseDisc : IDisc
         }
     }
 
-    [NotMapped]
-    public string? GlobalDiscId
-    {
-        get => this.Disc?.GlobalDiscId;
-        set
-        {
-            if (this.Disc != null)
-            {
-                this.Disc.GlobalDiscId = value;
-            }
-        }
-    }
+    /// <summary>
+    /// This pressing's globally-stable Disc ID (AACS Disc ID for Blu-ray/UHD; libdvdread DVDDiscID
+    /// for DVD). The id identifies a physical pressing, so it lives on the release-disc rather than
+    /// the shared canonical <see cref="Disc"/>: two releases whose discs share a content hash each
+    /// carry their own id here. Globally unique across release-discs; add-only; optional (absent on
+    /// MKV-only rips).
+    /// </summary>
+    public string? GlobalDiscId { get; set; }
 
     [HotChocolate.Data.UseFiltering]
     [HotChocolate.Data.UseSorting]
     [NotMapped]
     public ICollection<Title> Titles => this.Disc?.Titles ?? Array.Empty<Title>();
+}
+
+public static class ReleaseDiscExtensions
+{
+    /// <summary>
+    /// The pressing's <b>effective</b> Disc ID: its own stored <see cref="ReleaseDisc.GlobalDiscId"/>
+    /// when present; otherwise the single distinct id shared by the other release-discs of the same
+    /// canonical <see cref="Disc"/> (which represent the same content, so usually the same pressing).
+    /// Returns <c>null</c> when it has no own id and its siblings either have none or disagree — a
+    /// genuine re-press collision where this pressing's id is unknown. The sibling fallback requires
+    /// <see cref="Disc.ReleaseDiscs"/> to be loaded; when it isn't, only the own id is considered.
+    /// </summary>
+    public static string? EffectiveGlobalDiscId(this ReleaseDisc releaseDisc)
+    {
+        if (releaseDisc is null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(releaseDisc.GlobalDiscId))
+        {
+            return releaseDisc.GlobalDiscId;
+        }
+
+        var siblings = releaseDisc.Disc?.ReleaseDiscs;
+        if (siblings is null)
+        {
+            return null;
+        }
+
+        return EffectiveGlobalDiscId(siblings.Select(s => s.GlobalDiscId));
+    }
+
+    /// <summary>
+    /// Computes the unambiguous id from a set of release-disc ids (typically the ids of every
+    /// release-disc sharing one canonical disc): the single distinct non-empty value, or <c>null</c>
+    /// when there are none or more than one (a collision).
+    /// </summary>
+    public static string? EffectiveGlobalDiscId(IEnumerable<string?> candidateIds)
+    {
+        string? found = null;
+        foreach (var id in candidateIds)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                continue;
+            }
+
+            if (found is null)
+            {
+                found = id;
+            }
+            else if (!string.Equals(found, id, StringComparison.OrdinalIgnoreCase))
+            {
+                return null; // siblings disagree — ambiguous
+            }
+        }
+
+        return found;
+    }
 }

--- a/code/TheDiscDb.Core/InputModels/ReleaseDiscFilterType.cs
+++ b/code/TheDiscDb.Core/InputModels/ReleaseDiscFilterType.cs
@@ -18,6 +18,6 @@ public class ReleaseDiscFilterType : FilterInputType<ReleaseDisc>
         descriptor.Field(d => d.Titles);
         descriptor.Field(d => d.Disc!.Format).Name("format");
         descriptor.Field(d => d.Disc!.ContentHash).Name("contentHash");
-        descriptor.Field(d => d.Disc!.GlobalDiscId).Name("globalDiscId");
+        descriptor.Field(d => d.GlobalDiscId).Name("globalDiscId");
     }
 }

--- a/code/TheDiscDb.Data.Import/DataImporter.cs
+++ b/code/TheDiscDb.Data.Import/DataImporter.cs
@@ -1335,7 +1335,16 @@
             }
 
             var referencedJson = await this.fileSystem.File.ReadAllText(referencedDiscPath, cancellationToken);
-            return JsonSerializer.Deserialize<Disc>(referencedJson, JsonOptions);
+            var referencedDisc = JsonSerializer.Deserialize<Disc>(referencedJson, JsonOptions);
+            if (referencedDisc is not null)
+            {
+                // This .ref is a different physical pressing (same content) than the referenced
+                // release, so its pressing id is the .ref's own globalDiscId — never inherit the
+                // referenced release's id.
+                referencedDisc.GlobalDiscId = reference.GlobalDiscId;
+            }
+
+            return referencedDisc;
         }
 
         private async Task<string> ResolveReferencedReleasePath(string dataRoot, string releasePath, CancellationToken cancellationToken)
@@ -1405,6 +1414,7 @@
                 Index = disc.Index,
                 Name = disc.Name,
                 Slug = disc.Slug,
+                GlobalDiscId = disc.GlobalDiscId,
                 Disc = canonicalDisc
             };
         }

--- a/code/TheDiscDb.Data.Import/Pipeline/DataImportItemFactory.cs
+++ b/code/TheDiscDb.Data.Import/Pipeline/DataImportItemFactory.cs
@@ -494,7 +494,16 @@ public class DataImportItemFactory
         }
 
         var referencedJson = await this.fileSystem.File.ReadAllText(referencedDiscPath, cancellationToken);
-        return JsonSerializer.Deserialize<Disc>(referencedJson, DataImporter.JsonOptions);
+        var referencedDisc = JsonSerializer.Deserialize<Disc>(referencedJson, DataImporter.JsonOptions);
+        if (referencedDisc is not null)
+        {
+            // The referenced disc.json carries the *referenced* release's pressing id. This .ref
+            // represents a different physical pressing (same content), so its id is the .ref's own
+            // globalDiscId — never inherit the referenced release's id.
+            referencedDisc.GlobalDiscId = reference.GlobalDiscId;
+        }
+
+        return referencedDisc;
     }
 
     private ReleaseDisc ToReleaseDisc(Disc disc)
@@ -504,6 +513,7 @@ public class DataImportItemFactory
             Index = disc.Index,
             Name = disc.Name,
             Slug = disc.Slug,
+            GlobalDiscId = disc.GlobalDiscId,
             Disc = disc
         };
     }

--- a/code/TheDiscDb.Data.Import/Pipeline/ItemHandlers/ReleaseDiscItemHandler.cs
+++ b/code/TheDiscDb.Data.Import/Pipeline/ItemHandlers/ReleaseDiscItemHandler.cs
@@ -32,6 +32,7 @@ public class ReleaseDiscItemHandler : ItemHandler<ReleaseDisc>
         fromDatabase.Index = newValue.Index;
         fromDatabase.Name = newValue.Name;
         fromDatabase.Slug = newValue.Slug;
+        fromDatabase.GlobalDiscId = newValue.GlobalDiscId;
 
         if (newValue.Disc == null)
         {

--- a/code/TheDiscDb.Data/Changes/DiscFields/DiscFieldsUpdate.cs
+++ b/code/TheDiscDb.Data/Changes/DiscFields/DiscFieldsUpdate.cs
@@ -64,10 +64,12 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
             SetIfChanged(original, original?.ContentHash, this.Proposed.ContentHash, v => disc.ContentHash = v);
         }
 
-        // GlobalDiscId is add-only, same rule as ContentHash.
-        if (string.IsNullOrEmpty(original?.GlobalDiscId))
+        // GlobalDiscId is add-only per pressing: fill it when this release-disc has none. A
+        // different non-empty id is rejected in validation (uniqueness / same-release re-press),
+        // so here we only populate an empty slot.
+        if (!string.IsNullOrEmpty(this.Proposed.GlobalDiscId) && string.IsNullOrEmpty(disc.GlobalDiscId))
         {
-            SetIfChanged(original, original?.GlobalDiscId, this.Proposed.GlobalDiscId, v => disc.GlobalDiscId = v);
+            disc.GlobalDiscId = this.Proposed.GlobalDiscId;
         }
     }
 
@@ -75,9 +77,10 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
         => $"Disc '{this.Proposed.TargetEntityKey}' no longer exists.";
 
     /// <summary>
-    /// Guards the unique <c>(Format, ContentHash)</c> index: when this change introduces a new
-    /// content hash, reject it up front if another disc already carries the same hash+format, rather
-    /// than letting <c>SaveChanges</c> throw an opaque unique-constraint violation during apply.
+    /// Guards the unique <c>(Format, ContentHash)</c> index and the global uniqueness of Disc IDs:
+    /// when this change introduces a new content hash or a new Disc ID, reject it up front if it
+    /// collides with a different disc, rather than letting <c>SaveChanges</c> throw an opaque
+    /// unique-constraint violation during apply.
     /// </summary>
     protected override async Task<ChangeValidationResult?> ValidateAdditionalAsync(
         SqlServerDataContext context,
@@ -89,7 +92,11 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
         // onto a disc that currently has none.
         var addingHash = !string.IsNullOrEmpty(this.Proposed.ContentHash)
             && string.IsNullOrEmpty(current.ContentHash);
-        if (!addingHash)
+
+        var proposedId = this.Proposed.GlobalDiscId;
+        var addingGlobalId = !string.IsNullOrEmpty(proposedId);
+
+        if (!addingHash && !addingGlobalId)
         {
             return null;
         }
@@ -100,20 +107,50 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
             return null; // missing-target is handled by the standard validation path
         }
 
-        var hash = this.Proposed.ContentHash;
-        var format = string.IsNullOrEmpty(this.Proposed.Format) ? target.Disc.Format : this.Proposed.Format;
         var targetDiscId = target.Disc.Id;
 
-        var conflictingDiscId = await context.Discs
-            .Where(d => d.Id != targetDiscId && d.ContentHash == hash && d.Format == format)
-            .Select(d => (int?)d.Id)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (conflictingDiscId is not null)
+        if (addingHash)
         {
-            return ChangeValidationResult.Conflict(
-                $"Content hash {hash} is already assigned to a different {format} disc. Content hashes are " +
-                "unique per format — the wrong disc may have been scanned or the hash entered for the wrong disc.");
+            var hash = this.Proposed.ContentHash;
+            var format = string.IsNullOrEmpty(this.Proposed.Format) ? target.Disc.Format : this.Proposed.Format;
+
+            var conflictingDiscId = await context.Discs
+                .Where(d => d.Id != targetDiscId && d.ContentHash == hash && d.Format == format)
+                .Select(d => (int?)d.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (conflictingDiscId is not null)
+            {
+                return ChangeValidationResult.Conflict(
+                    $"Content hash {hash} is already assigned to a different {format} disc. Content hashes are " +
+                    "unique per format — the wrong disc may have been scanned or the hash entered for the wrong disc.");
+            }
+        }
+
+        if (addingGlobalId)
+        {
+            // A Disc ID identifies one physical pressing (one release-disc). Reject if another
+            // release-disc already owns it, or if THIS release-disc already carries a different id
+            // (a same-release re-press needs review rather than a silent overwrite).
+            var ownerReleaseDiscId = await context.ReleaseDiscs
+                .Where(rd => rd.GlobalDiscId == proposedId)
+                .Select(rd => (int?)rd.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (ownerReleaseDiscId is not null && ownerReleaseDiscId != target.Id)
+            {
+                return ChangeValidationResult.Conflict(
+                    $"Disc ID {proposedId} is already assigned to a different release-disc. Each Disc ID " +
+                    "identifies a single pressing — this may indicate the same disc recorded under two releases.");
+            }
+
+            if (!string.IsNullOrEmpty(target.GlobalDiscId)
+                && !string.Equals(target.GlobalDiscId, proposedId, StringComparison.OrdinalIgnoreCase))
+            {
+                return ChangeValidationResult.Conflict(
+                    $"This disc already has Disc ID {target.GlobalDiscId}; the submitted {proposedId} differs — " +
+                    "needs review (possible re-press or mis-scan).");
+            }
         }
 
         return null;
@@ -151,7 +188,8 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
             AppendIfDifferent(drifted, nameof(original.ContentHash), original.ContentHash, current.ContentHash);
         }
 
-        // GlobalDiscId is add-only: same drift rule as ContentHash.
+        // GlobalDiscId is add-only: only flag drift when a new id is being proposed
+        // (original was null/empty and proposed provides a value).
         if (!string.IsNullOrEmpty(this.Proposed.GlobalDiscId) && string.IsNullOrEmpty(original.GlobalDiscId))
         {
             AppendIfDifferent(drifted, nameof(original.GlobalDiscId), original.GlobalDiscId, current.GlobalDiscId);
@@ -176,6 +214,7 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
             _ => null,
         };
 
+        // GlobalDiscId is the pressing's id on the ReleaseDisc; read it from the concrete models.
         var globalDiscId = disc switch
         {
             ReleaseDisc rd => rd.GlobalDiscId,
@@ -202,7 +241,7 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
     /// when proposed slug is null/empty. Returns null on any miss; does NOT
     /// use <c>AsNoTracking</c> so the apply path mutates the same tracked row.
     /// </summary>
-    internal static async Task<ReleaseDisc?> ResolveDiscAsync(
+    public static async Task<ReleaseDisc?> ResolveDiscAsync(
         SqlServerDataContext context,
         DiscFieldsDetails details,
         CancellationToken cancellationToken)
@@ -224,7 +263,7 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
             var ms = details.MediaItemSlug;
             release = await context.Releases
                 .Include(r => r.Discs)
-                    .ThenInclude(d => d.Disc)
+                    .ThenInclude(d => d.Disc!)
                 .FirstOrDefaultAsync(
                     r => r.Slug == releaseSlug && r.MediaItem != null && r.MediaItem.Slug == ms,
                     cancellationToken);
@@ -234,7 +273,7 @@ public sealed class DiscFieldsUpdate : ChangeBase<DiscFieldsDetails>
             var bs = details.BoxsetSlug;
             release = await context.Releases
                 .Include(r => r.Discs)
-                    .ThenInclude(d => d.Disc)
+                    .ThenInclude(d => d.Disc!)
                 .FirstOrDefaultAsync(
                     r => r.Slug == releaseSlug && r.Boxset != null && r.Boxset.Slug == bs,
                     cancellationToken);

--- a/code/TheDiscDb.Data/SqlServerDataContext.cs
+++ b/code/TheDiscDb.Data/SqlServerDataContext.cs
@@ -47,11 +47,13 @@ public class SqlServerDataContext : DbContext
         disc.HasMany(x => x.Titles).WithOne(x => x.Disc);
         disc.HasMany(x => x.ReleaseDiscs).WithOne(x => x.Disc);
         disc.HasIndex(x => new { x.Format, x.ContentHash }).IsUnique();
-        disc.HasIndex(x => x.GlobalDiscId).HasFilter("[GlobalDiscId] IS NOT NULL");
         disc.Ignore(x => x.Index);
         disc.Ignore(x => x.Slug);
         disc.Ignore(x => x.Name);
         disc.Ignore(x => x.Release);
+        // GlobalDiscId is a transient carrier read from disc*.json and moved onto ReleaseDisc at
+        // import; it is not a column on the shared canonical disc.
+        disc.Ignore(x => x.GlobalDiscId);
 
         var releaseDisc = modelBuilder.Entity<ReleaseDisc>();
         releaseDisc.HasKey(x => x.Id);
@@ -65,8 +67,10 @@ public class SqlServerDataContext : DbContext
             .OnDelete(DeleteBehavior.Restrict);
         releaseDisc.Ignore(x => x.Format);
         releaseDisc.Ignore(x => x.ContentHash);
-        releaseDisc.Ignore(x => x.GlobalDiscId);
         releaseDisc.Ignore(x => x.Titles);
+        releaseDisc.Property(x => x.GlobalDiscId).HasMaxLength(450);
+        // A given Disc ID identifies one physical pressing: globally unique across release-discs.
+        releaseDisc.HasIndex(x => x.GlobalDiscId).IsUnique().HasFilter("[GlobalDiscId] IS NOT NULL");
         releaseDisc.HasIndex(x => new { x.ReleaseId, x.Slug }).IsUnique().HasFilter("[Slug] IS NOT NULL");
         releaseDisc.HasIndex(x => new { x.ReleaseId, x.Index }).IsUnique();
 

--- a/code/TheDiscDb.DatabaseMigration/Migrations/20260719154235_MoveGlobalDiscIdToReleaseDisc.Designer.cs
+++ b/code/TheDiscDb.DatabaseMigration/Migrations/20260719154235_MoveGlobalDiscIdToReleaseDisc.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TheDiscDb.Web.Data;
 
@@ -11,9 +12,11 @@ using TheDiscDb.Web.Data;
 namespace TheDiscDb.Web.Migrations
 {
     [DbContext(typeof(SqlServerDataContext))]
-    partial class SqlServerDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260719154235_MoveGlobalDiscIdToReleaseDisc")]
+    partial class MoveGlobalDiscIdToReleaseDisc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/TheDiscDb.DatabaseMigration/Migrations/20260719154235_MoveGlobalDiscIdToReleaseDisc.cs
+++ b/code/TheDiscDb.DatabaseMigration/Migrations/20260719154235_MoveGlobalDiscIdToReleaseDisc.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TheDiscDb.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class MoveGlobalDiscIdToReleaseDisc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GlobalDiscId",
+                table: "ReleaseDiscs",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            // Preserve existing ids: the id used to live on the shared canonical disc; move each
+            // disc's value onto ONE of its release-discs. A given id value is now globally unique
+            // per release-disc, so if the legacy (non-unique) column recorded the same value under
+            // multiple discs/releases, keep only the lowest release-disc for that value via
+            // ROW_NUMBER — otherwise the new unique index would fail to build.
+            migrationBuilder.Sql(
+                @"WITH ranked AS (
+                      SELECT rd.[Id] AS ReleaseDiscId,
+                             d.[GlobalDiscId] AS Val,
+                             ROW_NUMBER() OVER (PARTITION BY d.[GlobalDiscId] ORDER BY rd.[Id]) AS rn
+                      FROM [ReleaseDiscs] rd
+                      INNER JOIN [Discs] d ON d.[Id] = rd.[DiscId]
+                      WHERE d.[GlobalDiscId] IS NOT NULL AND d.[GlobalDiscId] <> ''
+                  )
+                  UPDATE rd
+                  SET rd.[GlobalDiscId] = ranked.Val
+                  FROM [ReleaseDiscs] rd
+                  INNER JOIN ranked ON ranked.ReleaseDiscId = rd.[Id]
+                  WHERE ranked.rn = 1;");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReleaseDiscs_GlobalDiscId",
+                table: "ReleaseDiscs",
+                column: "GlobalDiscId",
+                unique: true,
+                filter: "[GlobalDiscId] IS NOT NULL");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Discs_GlobalDiscId",
+                table: "Discs");
+
+            migrationBuilder.DropColumn(
+                name: "GlobalDiscId",
+                table: "Discs");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GlobalDiscId",
+                table: "Discs",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            // Best-effort restore of the scalar column: a canonical disc may map to several
+            // release-discs, so keep the lowest id per disc (the scalar model holds only one).
+            migrationBuilder.Sql(
+                @"UPDATE d
+                  SET d.[GlobalDiscId] = x.[GlobalDiscId]
+                  FROM [Discs] d
+                  INNER JOIN (
+                      SELECT [DiscId], MIN([GlobalDiscId]) AS [GlobalDiscId]
+                      FROM [ReleaseDiscs]
+                      WHERE [GlobalDiscId] IS NOT NULL
+                      GROUP BY [DiscId]
+                  ) x ON x.[DiscId] = d.[Id];");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReleaseDiscs_GlobalDiscId",
+                table: "ReleaseDiscs");
+
+            migrationBuilder.DropColumn(
+                name: "GlobalDiscId",
+                table: "ReleaseDiscs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Discs_GlobalDiscId",
+                table: "Discs",
+                column: "GlobalDiscId",
+                filter: "[GlobalDiscId] IS NOT NULL");
+        }
+    }
+}

--- a/code/TheDiscDb.UnitTests/Data/Changes/DiscFields/DiscFieldsUpdateTests.cs
+++ b/code/TheDiscDb.UnitTests/Data/Changes/DiscFields/DiscFieldsUpdateTests.cs
@@ -1,5 +1,6 @@
 namespace TheDiscDb.UnitTests.Data.Changes.DiscFields;
 
+using System.Linq;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using TheDiscDb.Data.Changes;
@@ -336,7 +337,7 @@ public class DiscFieldsUpdateTests
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
         var snapshot = JsonSerializer.Serialize(
-            DiscFieldsUpdate.SnapshotFrom(seed.Disc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug),
+            DiscFieldsUpdate.SnapshotFrom(seed.ReleaseDisc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug),
             JsonOptions);
 
         const string newDiscId = "A734E4BEE726B8943F2E8817E3956EFC5F786C8B";
@@ -349,19 +350,20 @@ public class DiscFieldsUpdateTests
     }
 
     [Test]
-    public async Task ApplyAsync_DoesNotOverwriteGlobalDiscId_WhenAlreadyPresent()
+    public async Task ApplyAsync_IsIdempotent_WhenGlobalDiscIdAlreadyPresent()
     {
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
         const string existing = "A734E4BEE726B8943F2E8817E3956EFC5F786C8B";
-        seed.Disc.GlobalDiscId = existing;
+        seed.ReleaseDisc.GlobalDiscId = existing;
         await db.SaveChangesAsync();
 
         var snapshot = JsonSerializer.Serialize(
-            DiscFieldsUpdate.SnapshotFrom(seed.Disc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug),
+            DiscFieldsUpdate.SnapshotFrom(seed.ReleaseDisc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug),
             JsonOptions);
 
-        var change = new DiscFieldsUpdate(MakeProposed(globalDiscId: "91C2EB717C4323D8807C01BA79011A6B"));
+        // Proposing the same id again is a no-op.
+        var change = new DiscFieldsUpdate(MakeProposed(globalDiscId: existing));
         await change.ApplyAsync(db, new TestApplyContext("admin", 1, 1, snapshot), CancellationToken.None);
         await db.SaveChangesAsync();
 
@@ -370,23 +372,58 @@ public class DiscFieldsUpdateTests
     }
 
     [Test]
-    public async Task ValidateAsync_ReturnsConflict_WhenGlobalDiscIdDrifts()
+    public async Task ValidateAsync_ReturnsConflict_WhenDiscAlreadyHasDifferentId()
     {
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
-        seed.Disc.GlobalDiscId = "A734E4BEE726B8943F2E8817E3956EFC5F786C8B";
+        const string existing = "A734E4BEE726B8943F2E8817E3956EFC5F786C8B";
+        seed.ReleaseDisc.GlobalDiscId = existing;
         await db.SaveChangesAsync();
 
-        // Snapshot taken when the disc had no Disc ID; the DB now has one -> drift.
-        var staleSnapshot = JsonSerializer.Serialize(
-            DiscFieldsUpdate.SnapshotFrom(seed.Disc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug) with { GlobalDiscId = null },
+        var snapshot = JsonSerializer.Serialize(
+            DiscFieldsUpdate.SnapshotFrom(seed.ReleaseDisc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug),
             JsonOptions);
 
-        var change = new DiscFieldsUpdate(MakeProposed(globalDiscId: "91C2EB717C4323D8807C01BA79011A6B"));
+        // This release-disc already carries an id; a different one is a conflict (re-press/mis-scan),
+        // never a silent overwrite.
+        const string second = "91C2EB717C4323D8807C01BA79011A6B";
+        var change = new DiscFieldsUpdate(MakeProposed(globalDiscId: second));
 
-        var result = await change.ValidateAsync(db, staleSnapshot, CancellationToken.None);
+        var result = await change.ValidateAsync(db, snapshot, CancellationToken.None);
 
         await Assert.That(result.IsConflict).IsTrue();
-        await Assert.That(result.ConflictReason).Contains("GlobalDiscId");
+        await Assert.That(result.ConflictReason).Contains("Disc ID");
+    }
+
+    [Test]
+    public async Task ValidateAsync_ReturnsConflict_WhenGlobalDiscIdOwnedByDifferentReleaseDisc()
+    {
+        using var db = ChangeTestSeed.CreateDbContext();
+        var seed = ChangeTestSeed.Seed(db);
+
+        // A different release-disc already owns the proposed id.
+        const string ownedId = "91C2EB717C4323D8807C01BA79011A6B";
+        var otherDisc = new TheDiscDb.InputModels.Disc
+        {
+            Slug = "disc-two",
+            Index = 1,
+            Name = "Disc Two",
+            Format = "Blu-ray",
+            ContentHash = "9999888877776666555544443333EEEE",
+        };
+        seed.Release.Discs.Add(new TheDiscDb.InputModels.ReleaseDisc { Slug = "disc-two", Index = 1, Name = "Disc Two", GlobalDiscId = ownedId, Disc = otherDisc });
+        await db.SaveChangesAsync();
+
+        var snapshot = JsonSerializer.Serialize(
+            DiscFieldsUpdate.SnapshotFrom(seed.ReleaseDisc, ChangeTestSeed.MediaItemSlug, null, ChangeTestSeed.ReleaseSlug),
+            JsonOptions);
+
+        // Target is the seed disc, but the id belongs to disc-two -> conflict.
+        var change = new DiscFieldsUpdate(MakeProposed(globalDiscId: ownedId));
+
+        var result = await change.ValidateAsync(db, snapshot, CancellationToken.None);
+
+        await Assert.That(result.IsConflict).IsTrue();
+        await Assert.That(result.ConflictReason).Contains("Disc ID");
     }
 }

--- a/code/TheDiscDb.UnitTests/Services/DiscId/DiscIdBackfillServiceTests.cs
+++ b/code/TheDiscDb.UnitTests/Services/DiscId/DiscIdBackfillServiceTests.cs
@@ -1,5 +1,6 @@
 namespace TheDiscDb.UnitTests.Services.DiscId;
 
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using TheDiscDb.Data.Changes;
 using TheDiscDb.Data.Changes.DiscFields;
@@ -29,8 +30,8 @@ public class DiscIdBackfillServiceTests
 
     private static async Task<string?> ReloadDiscIdAsync(SqlServerDataContext db)
     {
-        var rd = await db.Set<ReleaseDisc>().Include(x => x.Disc).FirstAsync(x => x.Slug == ChangeTestSeed.DiscSlug);
-        return rd.Disc!.GlobalDiscId;
+        var rd = await db.Set<ReleaseDisc>().FirstAsync(x => x.Slug == ChangeTestSeed.DiscSlug);
+        return rd.GlobalDiscId;
     }
 
     [Test]
@@ -58,7 +59,7 @@ public class DiscIdBackfillServiceTests
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
         seed.Disc.ContentHash = ContentHash;
-        seed.Disc.GlobalDiscId = DiscId;
+        seed.ReleaseDisc.GlobalDiscId = DiscId;
         await db.SaveChangesAsync();
 
         var result = await CreateService(db).AttachAsync("user-1", ContentHash, DiscId, target: null);
@@ -68,21 +69,48 @@ public class DiscIdBackfillServiceTests
     }
 
     [Test]
-    public async Task AttachAsync_DifferentExistingDiscId_ConflictsWithoutTouchingDb()
+    public async Task AttachAsync_DifferentIdOnSameDisc_Conflicts()
     {
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
         seed.Disc.ContentHash = ContentHash;
-        seed.Disc.GlobalDiscId = OtherDiscId;
+        seed.ReleaseDisc.GlobalDiscId = OtherDiscId;
         await db.SaveChangesAsync();
 
+        // This release-disc already has an id; a different one needs review (re-press or mis-scan),
+        // not a silent overwrite.
         var result = await CreateService(db).AttachAsync("user-1", ContentHash, DiscId, target: null);
 
         await Assert.That(result.Outcome).IsEqualTo(AttachDiscIdOutcome.Conflict);
-        await Assert.That(result.ExistingGlobalDiscId).IsEqualTo(OtherDiscId);
 
-        // DB unchanged.
+        // DB untouched (still the original id).
         await Assert.That(await ReloadDiscIdAsync(db)).IsEqualTo(OtherDiscId);
+
+        var change = await db.Set<EditSuggestionChange>().FirstAsync();
+        await Assert.That(change.Status).IsEqualTo(EditSuggestionChangeStatus.Pending);
+        await Assert.That(change.ConflictReason).IsNotNull();
+    }
+
+    [Test]
+    public async Task AttachAsync_IdOwnedByDifferentReleaseDisc_ConflictsWithoutTouchingDb()
+    {
+        using var db = ChangeTestSeed.CreateDbContext();
+        var seed = ChangeTestSeed.Seed(db);
+        seed.Disc.ContentHash = ContentHash;
+
+        // A different release-disc already owns DiscId.
+        const string otherHash = "9999888877776666555544443333EEEE";
+        var otherDisc = new Disc { Slug = "disc-two", Index = 1, Name = "Disc Two", Format = "Blu-ray", ContentHash = otherHash };
+        seed.Release.Discs.Add(new ReleaseDisc { Slug = "disc-two", Index = 1, Name = "Disc Two", GlobalDiscId = DiscId, Disc = otherDisc });
+        await db.SaveChangesAsync();
+
+        // Submitting DiscId for the first disc (matched by its content hash) collides across pressings.
+        var result = await CreateService(db).AttachAsync("user-1", ContentHash, DiscId, target: null);
+
+        await Assert.That(result.Outcome).IsEqualTo(AttachDiscIdOutcome.Conflict);
+
+        // First disc untouched (still has no id).
+        await Assert.That(await ReloadDiscIdAsync(db)).IsNull();
 
         // A pending change with a conflict note is filed for review (not applied).
         var change = await db.Set<EditSuggestionChange>().FirstAsync();
@@ -174,8 +202,8 @@ public class DiscIdBackfillServiceTests
         await Assert.That(result.DiscSlug).IsEqualTo("disc-two");
 
         // disc-two received the id; the CTA target disc-one is untouched.
-        var applied = await db.Set<ReleaseDisc>().Include(x => x.Disc).FirstAsync(x => x.Slug == "disc-two");
-        await Assert.That(applied.Disc!.GlobalDiscId).IsEqualTo(DiscId);
+        var applied = await db.Set<ReleaseDisc>().FirstAsync(x => x.Slug == "disc-two");
+        await Assert.That(applied.GlobalDiscId).IsEqualTo(DiscId);
         await Assert.That(await ReloadDiscIdAsync(db)).IsNull();
     }
 }

--- a/code/TheDiscDb.UnitTests/Services/DiscLookup/DiscLookupQueryTests.cs
+++ b/code/TheDiscDb.UnitTests/Services/DiscLookup/DiscLookupQueryTests.cs
@@ -1,5 +1,6 @@
 namespace TheDiscDb.UnitTests.Services.DiscLookup;
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TheDiscDb.InputModels;
@@ -16,7 +17,7 @@ public class DiscLookupQueryTests
     {
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
-        seed.Disc.GlobalDiscId = AacsId;
+        seed.ReleaseDisc.GlobalDiscId = AacsId;
         seed.Disc.ContentHash = "AAAA1111BBBB2222CCCC3333DDDD4444";
         await db.SaveChangesAsync();
 
@@ -44,7 +45,7 @@ public class DiscLookupQueryTests
     {
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
-        seed.Disc.GlobalDiscId = AacsId;
+        seed.ReleaseDisc.GlobalDiscId = AacsId;
         await db.SaveChangesAsync();
 
         var result = await DiscLookupQuery.LookupAsync(db, AacsId.ToLowerInvariant());
@@ -70,7 +71,7 @@ public class DiscLookupQueryTests
     {
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
-        seed.Disc.GlobalDiscId = DvdId;
+        seed.ReleaseDisc.GlobalDiscId = DvdId;
         seed.Disc.Format = "DVD";
         await db.SaveChangesAsync();
 
@@ -87,7 +88,7 @@ public class DiscLookupQueryTests
 
         using var db = ChangeTestSeed.CreateDbContext();
         var seed = ChangeTestSeed.Seed(db);
-        seed.Disc.GlobalDiscId = AacsId;
+        seed.ReleaseDisc.GlobalDiscId = AacsId;
         seed.Disc.ContentHash = contentHash;
         seed.Disc.Format = "UHD";
         seed.Title.Item!.Type = "MainMovie";
@@ -173,6 +174,79 @@ public class DiscLookupQueryTests
         await Assert.That(subtitle.LanguageCode).IsEqualTo("eng");
         await Assert.That(subtitle.Language).IsEqualTo("English");
         await Assert.That(subtitle.Description).IsEqualTo("Forced subtitles");
+    }
+
+    [Test]
+    public async Task LookupAllAsync_SharedPressing_FindsBothReleases()
+    {
+        using var db = ChangeTestSeed.CreateDbContext();
+        var seed = ChangeTestSeed.Seed(db);
+        seed.ReleaseDisc.GlobalDiscId = AacsId;   // standalone release stores the id
+        seed.Disc.ContentHash = "AAAA1111BBBB2222CCCC3333DDDD4444";
+
+        // A second release (e.g. a boxset copy via .ref) whose release-disc shares the SAME canonical
+        // disc but stores no id of its own — it should be found via the shared-pressing fallback.
+        var otherRelease = new TheDiscDb.InputModels.Release
+        {
+            Slug = "boxset-release",
+            Title = "Boxset Release",
+            Year = 2021,
+            MediaItem = seed.MediaItem,
+        };
+        otherRelease.Discs.Add(new TheDiscDb.InputModels.ReleaseDisc
+        {
+            Slug = ChangeTestSeed.DiscSlug,
+            Index = ChangeTestSeed.DiscIndex,
+            Name = "Original Disc Name",
+            Disc = seed.Disc,          // same canonical disc
+            GlobalDiscId = null,       // no own id -> relies on fallback
+        });
+        seed.MediaItem.Releases.Add(otherRelease);
+        await db.SaveChangesAsync();
+
+        var results = await DiscLookupQuery.LookupAllAsync(db, AacsId);
+
+        await Assert.That(results.Count).IsEqualTo(2);
+        // Both report the same (effective) Disc ID.
+        await Assert.That(results.All(r => r.GlobalDiscId == AacsId)).IsTrue();
+        // Both releases are represented.
+        var releaseSlugs = results.Select(r => r.Release!.Slug).ToList();
+        await Assert.That(releaseSlugs).Contains(ChangeTestSeed.ReleaseSlug);
+        await Assert.That(releaseSlugs).Contains("boxset-release");
+    }
+
+    [Test]
+    public async Task LookupAllAsync_Collision_ExcludesReleaseDiscWithDifferentId()
+    {
+        using var db = ChangeTestSeed.CreateDbContext();
+        var seed = ChangeTestSeed.Seed(db);
+        seed.ReleaseDisc.GlobalDiscId = AacsId;
+        seed.Disc.ContentHash = "AAAA1111BBBB2222CCCC3333DDDD4444";
+
+        // A re-press: same content (same canonical disc) but a DIFFERENT Disc ID.
+        var otherRelease = new TheDiscDb.InputModels.Release
+        {
+            Slug = "repress-release",
+            Title = "Re-press Release",
+            Year = 2022,
+            MediaItem = seed.MediaItem,
+        };
+        otherRelease.Discs.Add(new TheDiscDb.InputModels.ReleaseDisc
+        {
+            Slug = ChangeTestSeed.DiscSlug,
+            Index = ChangeTestSeed.DiscIndex,
+            Name = "Original Disc Name",
+            Disc = seed.Disc,
+            GlobalDiscId = DvdId,      // different id -> a distinct pressing
+        });
+        seed.MediaItem.Releases.Add(otherRelease);
+        await db.SaveChangesAsync();
+
+        // Querying one id returns only its own release-disc, never the re-press.
+        var results = await DiscLookupQuery.LookupAllAsync(db, AacsId);
+
+        await Assert.That(results.Count).IsEqualTo(1);
+        await Assert.That(results[0].Release!.Slug).IsEqualTo(ChangeTestSeed.ReleaseSlug);
     }
 
     [Test]

--- a/code/TheDiscDb.UnitTests/Services/EditSuggestions/DiscIdConflictResolutionTests.cs
+++ b/code/TheDiscDb.UnitTests/Services/EditSuggestions/DiscIdConflictResolutionTests.cs
@@ -1,0 +1,220 @@
+namespace TheDiscDb.UnitTests.Services.EditSuggestions;
+
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+using TheDiscDb.Data.Changes;
+using TheDiscDb.Data.Changes.DiscFields;
+using TheDiscDb.InputModels;
+using TheDiscDb.Services.EditSuggestions;
+using TheDiscDb.Web.Data;
+
+public class DiscIdConflictResolutionTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly CancellationToken CT = CancellationToken.None;
+
+    private const string Hash = "AAAA1111BBBB2222CCCC3333DDDD4444";
+    private const string IdA = "A734E4BEE726B8943F2E8817E3956EFC5F786C8B";
+    private const string IdB = "91C2EB717C4323D8807C01BA79011A6B";
+
+    private static SqlServerDataContext CreateDb() =>
+        new(new DbContextOptionsBuilder<SqlServerDataContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+
+    private static IChangeFactory CreateFactory() => new ChangeFactory(new IChangeBuilder[]
+    {
+        new ChangeBuilder<DiscFieldsDetails>(DiscFieldsUpdate.Key, (d, opts) => new DiscFieldsUpdate(d, opts)),
+    });
+
+    // Two releases of the same movie whose discs share one canonical Disc (same content). Release A
+    // stores IdA; release B (a re-pressed edition) stores nothing. A boxset release also shares the
+    // same canonical disc (a copied "existing disc") — it must never be offered as an attribution
+    // target, so it's here to prove it gets excluded.
+    private static (int ReleaseDiscBId, int BoxsetReleaseDiscId, SqlServerDataContext Db) Seed()
+    {
+        var db = CreateDb();
+        var disc = new Disc { Format = "Blu-ray", ContentHash = Hash };
+
+        var media = new MediaItem { Slug = "the-movie", Title = "The Movie", Year = 2020, Type = "movie" };
+        var releaseA = new Release { Slug = "release-a", Title = "A", Year = 2020, MediaItem = media };
+        releaseA.Discs.Add(new ReleaseDisc { Slug = "disc-1", Index = 1, Name = "Disc 1", Disc = disc, GlobalDiscId = IdA });
+        var releaseB = new Release { Slug = "release-b", Title = "B", Year = 2021, MediaItem = media };
+        var rdB = new ReleaseDisc { Slug = "disc-1", Index = 1, Name = "Disc 1", Disc = disc };
+        releaseB.Discs.Add(rdB);
+        media.Releases.Add(releaseA);
+        media.Releases.Add(releaseB);
+
+        // A boxset whose (single) release includes the same canonical disc, copied from the item.
+        var boxsetRelease = new Release { Slug = "the-boxset", Title = "The Boxset", Year = 2022 };
+        var rdBoxset = new ReleaseDisc { Slug = "disc-1", Index = 1, Name = "Disc 1", Disc = disc };
+        boxsetRelease.Discs.Add(rdBoxset);
+        var boxset = new Boxset { Slug = "the-boxset", Title = "The Boxset", Release = boxsetRelease };
+
+        db.Add(media);
+        db.Add(boxset);
+        db.SaveChanges();
+        return (rdB.Id, rdBoxset.Id, db);
+    }
+
+    private static async Task<EditSuggestionChange> FileConflictAsync(SqlServerDataContext db, EditSuggestionReviewService review, IChangeFactory factory)
+    {
+        var history = new EditSuggestionHistoryService(db);
+        var submit = new EditSuggestionService(db, factory, history);
+
+        // A change targeting release A proposing a DIFFERENT id (IdB) — conflicts because A has IdA.
+        var proposed = new DiscFieldsDetails("the-movie", null, "release-a", "disc-1", 1, "Disc 1", "Blu-ray", Hash, IdB);
+        var snapshot = proposed with { GlobalDiscId = null };
+        var suggestion = await submit.SubmitAsync("user-1", EditSuggestionSource.Web, null,
+            new List<SubmitChangeInput> { new(DiscFieldsUpdate.Key, JsonSerializer.Serialize(proposed, JsonOptions), JsonSerializer.Serialize(snapshot, JsonOptions)) }, CT);
+
+        var change = suggestion.Changes.First();
+        var approved = await review.ApproveChangeAsync(suggestion.Id, change.Id, "admin-1", null, CT);
+        await Assert.That(approved!.Status).IsEqualTo(EditSuggestionChangeStatus.Conflicted);
+        return approved;
+    }
+
+    [Test]
+    public async Task GetDiscIdConflictContext_ReturnsSubmittedIdAndCandidates()
+    {
+        var (_, _, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        var ctx = await review.GetDiscIdConflictContextAsync(change.SuggestionId, change.Id, CT);
+
+        await Assert.That(ctx).IsNotNull();
+        await Assert.That(ctx!.SubmittedGlobalDiscId).IsEqualTo(IdB);
+        await Assert.That(ctx.TargetCurrentGlobalDiscId).IsEqualTo(IdA);
+        // Only the two ITEM release-discs (A with IdA, B with none) are candidates — the boxset
+        // release-disc that shares the same canonical disc is excluded (it inherits, never owns).
+        await Assert.That(ctx.Candidates.Count).IsEqualTo(2);
+        await Assert.That(ctx.Candidates.Any(c => c.ReleaseSlug == "release-b" && c.CurrentGlobalDiscId == null)).IsTrue();
+        await Assert.That(ctx.Candidates.Any(c => c.ReleaseSlug == "the-boxset")).IsFalse();
+    }
+
+    [Test]
+    public async Task GetDiscIdConflictContext_ExcludesBoxsetReleaseDiscs()
+    {
+        var (_, boxsetReleaseDiscId, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        var ctx = await review.GetDiscIdConflictContextAsync(change.SuggestionId, change.Id, CT);
+
+        await Assert.That(ctx).IsNotNull();
+        await Assert.That(ctx!.Candidates.Any(c => c.ReleaseDiscId == boxsetReleaseDiscId)).IsFalse();
+    }
+
+    [Test]
+    public async Task AttributeDiscId_AssignsSubmittedIdToChosenReleaseDisc_AndLeavesOriginalIntact()
+    {
+        var (releaseDiscBId, _, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        // Attribute IdB to release B (the re-pressed sibling that had no id).
+        var result = await review.AttributeDiscIdAsync(change.SuggestionId, change.Id, releaseDiscBId, "admin-1", CT);
+
+        await Assert.That(result!.Status).IsEqualTo(EditSuggestionChangeStatus.Applied);
+
+        var rdB = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Id == releaseDiscBId);
+        await Assert.That(rdB.GlobalDiscId).IsEqualTo(IdB);
+
+        // Release A keeps its original id untouched.
+        var rdA = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Release!.Slug == "release-a");
+        await Assert.That(rdA.GlobalDiscId).IsEqualTo(IdA);
+    }
+
+    [Test]
+    public async Task AttributeDiscId_Conflicts_WhenDestinationAlreadyHasDifferentId()
+    {
+        var (_, _, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        // Attributing to release A (which already has IdA) must not overwrite it.
+        var rdAId = await db.Set<ReleaseDisc>().Where(rd => rd.Release!.Slug == "release-a").Select(rd => rd.Id).FirstAsync();
+        var result = await review.AttributeDiscIdAsync(change.SuggestionId, change.Id, rdAId, "admin-1", CT);
+
+        await Assert.That(result!.Status).IsEqualTo(EditSuggestionChangeStatus.Conflicted);
+        var rdA = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Id == rdAId);
+        await Assert.That(rdA.GlobalDiscId).IsEqualTo(IdA);
+    }
+
+    [Test]
+    public async Task AttributeDiscId_Conflicts_WhenDestinationIsBoxset()
+    {
+        var (_, boxsetReleaseDiscId, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        // A boxset release-disc inherits its id — refuse to attribute even if explicitly requested.
+        var result = await review.AttributeDiscIdAsync(change.SuggestionId, change.Id, boxsetReleaseDiscId, "admin-1", CT);
+
+        await Assert.That(result!.Status).IsEqualTo(EditSuggestionChangeStatus.Conflicted);
+        var rdBoxset = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Id == boxsetReleaseDiscId);
+        await Assert.That(rdBoxset.GlobalDiscId).IsNull();
+    }
+
+    [Test]
+    public async Task SwapDiscId_AssignsSubmittedToTarget_AndMovesDisplacedIdToSibling()
+    {
+        var (releaseDiscBId, _, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        // Target A has IdA; submitted is IdB. Swap: A becomes IdB, and A's old IdA moves to sibling B.
+        var result = await review.SwapDiscIdAsync(change.SuggestionId, change.Id, releaseDiscBId, "admin-1", CT);
+
+        await Assert.That(result!.Status).IsEqualTo(EditSuggestionChangeStatus.Applied);
+
+        var rdA = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Release!.Slug == "release-a");
+        await Assert.That(rdA.GlobalDiscId).IsEqualTo(IdB);
+
+        var rdB = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Id == releaseDiscBId);
+        await Assert.That(rdB.GlobalDiscId).IsEqualTo(IdA);
+
+        // A second applied change was recorded for the sibling so the displaced id syncs to /data.
+        var changes = await db.EditSuggestionChanges
+            .Where(c => c.SuggestionId == change.SuggestionId).ToListAsync();
+        await Assert.That(changes.Count).IsEqualTo(2);
+        await Assert.That(changes.All(c => c.Status == EditSuggestionChangeStatus.Applied)).IsTrue();
+        var siblingChange = changes.First(c => c.Id != change.Id);
+        var siblingProposed = JsonSerializer.Deserialize<DiscFieldsDetails>(siblingChange.ProposedJson, JsonOptions);
+        await Assert.That(siblingProposed!.ReleaseSlug).IsEqualTo("release-b");
+        await Assert.That(siblingProposed.GlobalDiscId).IsEqualTo(IdA);
+
+        // The primary change is an OVERWRITE: its snapshot records the displaced IdA (what authorises
+        // the file applier to overwrite), and its proposed carries IdB.
+        var primaryProposed = JsonSerializer.Deserialize<DiscFieldsDetails>(change.ProposedJson, JsonOptions);
+        var primarySnapshot = JsonSerializer.Deserialize<DiscFieldsDetails>(change.OriginalSnapshotJson!, JsonOptions);
+        await Assert.That(primaryProposed!.GlobalDiscId).IsEqualTo(IdB);
+        await Assert.That(primarySnapshot!.GlobalDiscId).IsEqualTo(IdA);
+    }
+
+    [Test]
+    public async Task SwapDiscId_Conflicts_WhenDestinationIsBoxset()
+    {
+        var (_, boxsetReleaseDiscId, db) = Seed();
+        var factory = CreateFactory();
+        var review = new EditSuggestionReviewService(db, factory, new EditSuggestionHistoryService(db));
+        var change = await FileConflictAsync(db, review, factory);
+
+        var result = await review.SwapDiscIdAsync(change.SuggestionId, change.Id, boxsetReleaseDiscId, "admin-1", CT);
+
+        await Assert.That(result!.Status).IsEqualTo(EditSuggestionChangeStatus.Conflicted);
+        // Nothing moved: A keeps IdA, the boxset stays empty.
+        var rdA = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Release!.Slug == "release-a");
+        await Assert.That(rdA.GlobalDiscId).IsEqualTo(IdA);
+        var rdBoxset = await db.Set<ReleaseDisc>().FirstAsync(rd => rd.Id == boxsetReleaseDiscId);
+        await Assert.That(rdBoxset.GlobalDiscId).IsNull();
+    }
+}

--- a/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor
+++ b/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor
@@ -115,14 +115,66 @@ else
             }
             @if (CanReview && change.Status == EditSuggestionChangeStatus.Conflicted)
             {
-                <div class="card-footer d-flex gap-2 align-items-center">
-                    <input class="form-control form-control-sm" style="max-width: 300px;"
-                           placeholder="Resolution note" @bind="conflictResolution" />
-                    <button class="btn btn-sm btn-warning" disabled="@isProcessing"
-                            @onclick="() => ResolveConflict(change.Id)">
-                        Resolve &amp; Apply
-                    </button>
-                </div>
+                @if (discIdConflicts.TryGetValue(change.Id, out var discConflict))
+                {
+                    <div class="card-footer">
+                        <p class="mb-2">
+                            Submitted Disc ID <code>@discConflict.SubmittedGlobalDiscId</code>;
+                            the target disc currently has
+                            @if (string.IsNullOrEmpty(discConflict.TargetCurrentGlobalDiscId))
+                            {
+                                <span>no id</span>
+                            }
+                            else
+                            {
+                                <code>@discConflict.TargetCurrentGlobalDiscId</code>
+                            }.
+                            Attribute the submitted id to the correct edition (a re-pressed sibling
+                            usually has no id yet). Or <strong>swap</strong> — assign the submitted id
+                            to this disc and move its current id to the selected sibling — when the
+                            existing id was mis-attributed:
+                        </p>
+                        <div class="d-flex flex-wrap gap-2 align-items-center">
+                            <select class="form-select form-select-sm w-auto"
+                                    value="@(selectedDestination.GetValueOrDefault(change.Id))"
+                                    @onchange="e => SetDestination(change.Id, e)">
+                                @foreach (var candidate in discConflict.Candidates)
+                                {
+                                    <option value="@candidate.ReleaseDiscId">@CandidateLabel(candidate)</option>
+                                }
+                            </select>
+                            <button class="btn btn-sm btn-success" disabled="@isProcessing"
+                                    @onclick="() => AttributeDiscId(change.Id)">
+                                Attribute Disc ID
+                            </button>
+                            @if (!string.IsNullOrEmpty(discConflict.TargetCurrentGlobalDiscId))
+                            {
+                                <button class="btn btn-sm btn-primary" disabled="@isProcessing"
+                                        @onclick="() => SwapDiscId(change.Id)">
+                                    Swap (assign here, move current to sibling)
+                                </button>
+                            }
+                            <input class="form-control form-control-sm w-auto"
+                                   placeholder="Rejection reason"
+                                   @bind="rejectionReasons[change.Id]" />
+                            <button class="btn btn-sm btn-danger" disabled="@isProcessing"
+                                    @onclick="() => RejectConflictedChange(change.Id)">
+                                Reject
+                            </button>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="card-footer d-flex gap-2 align-items-center">
+                        <input class="form-control form-control-sm w-auto"
+                               placeholder="Resolution note" @bind="conflictResolution" />
+                        <button class="btn btn-sm btn-warning" disabled="@isProcessing"
+                                @onclick="() => ResolveConflict(change.Id)">
+                            Resolve &amp; Apply
+                        </button>
+                    </div>
+                }
             }
         </div>
     }

--- a/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor.cs
+++ b/code/TheDiscDb/Components/Pages/Admin/EditSuggestionDetail.razor.cs
@@ -38,6 +38,10 @@ public partial class EditSuggestionDetail : ComponentBase
     private string conflictResolution = string.Empty;
     private Dictionary<int, string> rejectionReasons = [];
 
+    // Disc ID conflict resolution context + the admin's chosen destination release-disc per change.
+    private Dictionary<int, DiscIdConflictContext> discIdConflicts = [];
+    private Dictionary<int, int> selectedDestination = [];
+
     private static readonly IReadOnlyCollection<string> IdentityFields =
     [
         "mediaItemSlug", "boxsetSlug", "releaseSlug",
@@ -64,6 +68,29 @@ public partial class EditSuggestionDetail : ComponentBase
             foreach (var change in suggestion.Changes)
             {
                 rejectionReasons.TryAdd(change.Id, string.Empty);
+            }
+
+            // Load Disc ID conflict context (submitted id, target id, candidate release-discs) for
+            // any conflicted disc.fields.update change so the admin can attribute the id correctly.
+            discIdConflicts = [];
+            foreach (var change in suggestion.Changes.Where(c =>
+                c.Status == EditSuggestionChangeStatus.Conflicted && c.Type == "disc.fields.update"))
+            {
+                var context = await ReviewService.GetDiscIdConflictContextAsync(SuggestionId, change.Id);
+                if (context is not null)
+                {
+                    discIdConflicts[change.Id] = context;
+                    if (!selectedDestination.ContainsKey(change.Id))
+                    {
+                        // Default to the first candidate that currently has no id (a likely re-pressed sibling).
+                        var preferred = context.Candidates.FirstOrDefault(c => string.IsNullOrEmpty(c.CurrentGlobalDiscId))
+                            ?? context.Candidates.FirstOrDefault();
+                        if (preferred is not null)
+                        {
+                            selectedDestination[change.Id] = preferred.ReleaseDiscId;
+                        }
+                    }
+                }
             }
         }
     }
@@ -189,6 +216,124 @@ public partial class EditSuggestionDetail : ComponentBase
         }
     }
 
+    private async Task AttributeDiscId(int changeId)
+    {
+        if (!selectedDestination.TryGetValue(changeId, out var destinationReleaseDiscId) || destinationReleaseDiscId <= 0)
+        {
+            actionMessage = "Please choose a release-disc to attribute the Disc ID to.";
+            actionSuccess = false;
+            return;
+        }
+
+        isProcessing = true;
+        actionMessage = null;
+
+        try
+        {
+            var userId = await GetAdminUserId();
+            var result = await ReviewService.AttributeDiscIdAsync(SuggestionId, changeId, destinationReleaseDiscId, userId);
+            if (result == null)
+            {
+                actionMessage = "Change not found or not resolvable.";
+                actionSuccess = false;
+            }
+            else if (result.Status == EditSuggestionChangeStatus.Applied)
+            {
+                actionMessage = $"Disc ID attributed. Change #{changeId} applied.";
+                actionSuccess = true;
+            }
+            else
+            {
+                actionMessage = $"Change #{changeId} still conflicted: {result.ConflictReason}";
+                actionSuccess = false;
+            }
+
+            await LoadSuggestion();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to attribute Disc ID for change {ChangeId}", changeId);
+            actionMessage = "An error occurred while attributing the Disc ID.";
+            actionSuccess = false;
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
+    private async Task SwapDiscId(int changeId)
+    {
+        if (!selectedDestination.TryGetValue(changeId, out var secondaryReleaseDiscId) || secondaryReleaseDiscId <= 0)
+        {
+            actionMessage = "Please choose the sibling release-disc that should receive the displaced Disc ID.";
+            actionSuccess = false;
+            return;
+        }
+
+        isProcessing = true;
+        actionMessage = null;
+
+        try
+        {
+            var userId = await GetAdminUserId();
+            var result = await ReviewService.SwapDiscIdAsync(SuggestionId, changeId, secondaryReleaseDiscId, userId);
+            if (result == null)
+            {
+                actionMessage = "Change not found or not resolvable.";
+                actionSuccess = false;
+            }
+            else if (result.Status == EditSuggestionChangeStatus.Applied)
+            {
+                actionMessage = $"Disc IDs swapped. Change #{changeId} applied.";
+                actionSuccess = true;
+            }
+            else
+            {
+                actionMessage = $"Change #{changeId} still conflicted: {result.ConflictReason}";
+                actionSuccess = false;
+            }
+
+            await LoadSuggestion();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to swap Disc ID for change {ChangeId}", changeId);
+            actionMessage = "An error occurred while swapping the Disc ID.";
+            actionSuccess = false;
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
+    private async Task RejectConflictedChange(int changeId)
+    {
+        isProcessing = true;
+        actionMessage = null;
+
+        try
+        {
+            var userId = await GetAdminUserId();
+            var reason = rejectionReasons.GetValueOrDefault(changeId);
+            var result = await ReviewService.RejectChangeAsync(SuggestionId, changeId, userId, reason);
+            actionMessage = result == null ? "Change not found." : $"Change #{changeId} rejected.";
+            actionSuccess = result != null;
+            await LoadSuggestion();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to reject conflicted change {ChangeId}", changeId);
+            actionMessage = "An error occurred while rejecting the change.";
+            actionSuccess = false;
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
     private async Task ApproveAll()
     {
         isProcessing = true;
@@ -232,6 +377,22 @@ public partial class EditSuggestionDetail : ComponentBase
 
     private bool HasRejectionReason(int changeId) =>
         rejectionReasons.TryGetValue(changeId, out var reason) && !string.IsNullOrWhiteSpace(reason);
+
+    private void SetDestination(int changeId, Microsoft.AspNetCore.Components.ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var id))
+        {
+            selectedDestination[changeId] = id;
+        }
+    }
+
+    private static string CandidateLabel(DiscIdConflictCandidate c)
+    {
+        var name = c.MediaTitle ?? c.MediaItemSlug ?? "(unknown)";
+        var disc = string.IsNullOrEmpty(c.DiscSlug) ? $"disc {c.DiscIndex}" : c.DiscSlug;
+        var has = string.IsNullOrEmpty(c.CurrentGlobalDiscId) ? "no id" : $"has {c.CurrentGlobalDiscId}";
+        return $"{name} / {c.ReleaseSlug} / {disc} — {has}";
+    }
 
     private bool CanReview => suggestion is not null && suggestion.Status.IsReviewable();
 

--- a/code/TheDiscDb/Components/Pages/Admin/EditSuggestions.razor.cs
+++ b/code/TheDiscDb/Components/Pages/Admin/EditSuggestions.razor.cs
@@ -11,19 +11,38 @@ public partial class EditSuggestions : ComponentBase
     [Inject]
     private IDbContextFactory<SqlServerDataContext> DbFactory { get; set; } = null!;
 
+    [Inject]
+    private NavigationManager Navigation { get; set; } = null!;
+
+    // Persisted in the query string so the chosen status survives navigation away and back.
+    [SupplyParameterFromQuery(Name = "status")]
+    public string? StatusQuery { get; set; }
+
     private List<EditSuggestion>? suggestions;
     private readonly EditSuggestionStatus[] statusList = Enum.GetValues<EditSuggestionStatus>();
     private EditSuggestionStatus selectedStatus = EditSuggestionStatus.Pending;
+    private EditSuggestionStatus? loadedStatus;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
-        await RefreshList();
+        selectedStatus = Enum.TryParse<EditSuggestionStatus>(this.StatusQuery, ignoreCase: true, out var parsed)
+            ? parsed
+            : EditSuggestionStatus.Pending;
+
+        // Only hit the database when the effective status actually changed (query navigation or
+        // first load), not on every re-render.
+        if (this.loadedStatus != selectedStatus)
+        {
+            this.loadedStatus = selectedStatus;
+            await RefreshList();
+        }
     }
 
-    private async Task OnStatusChanged(EditSuggestionStatus newStatus)
+    private void OnStatusChanged(EditSuggestionStatus newStatus)
     {
-        selectedStatus = newStatus;
-        await RefreshList();
+        // Update the URL; OnParametersSetAsync re-reads the query and refreshes the list.
+        this.Navigation.NavigateTo(
+            this.Navigation.GetUriWithQueryParameter("status", newStatus.ToString()));
     }
 
     private async Task RefreshList()

--- a/code/TheDiscDb/Components/Pages/Admin/Index.razor.cs
+++ b/code/TheDiscDb/Components/Pages/Admin/Index.razor.cs
@@ -15,14 +15,32 @@ public partial class Index : ComponentBase
     [Inject]
     private IdEncoder IdEncoder { get; set; } = null!;
 
+    [Inject]
+    private NavigationManager Navigation { get; set; } = null!;
+
+    // Persisted in the query string so the chosen status survives navigation away and back.
+    [SupplyParameterFromQuery(Name = "status")]
+    public string? StatusQuery { get; set; }
+
     private IQueryable<UserContribution>? PendingContributions { get; set; }
     private IQueryable<UserContributionBoxset>? PendingBoxsets { get; set; }
     private readonly UserContributionStatus[] statusList = Enum.GetValues<UserContributionStatus>();
     private UserContributionStatus selectedStatus = UserContributionStatus.ReadyForReview;
+    private UserContributionStatus? loadedStatus;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
-        await RefreshList();
+        selectedStatus = Enum.TryParse<UserContributionStatus>(this.StatusQuery, ignoreCase: true, out var parsed)
+            ? parsed
+            : UserContributionStatus.ReadyForReview;
+
+        // Only hit the database when the effective status actually changed (query navigation or
+        // first load), not on every re-render.
+        if (this.loadedStatus != selectedStatus)
+        {
+            this.loadedStatus = selectedStatus;
+            await RefreshList();
+        }
     }
 
     private async Task RefreshList()
@@ -49,9 +67,10 @@ public partial class Index : ComponentBase
         PendingBoxsets = boxsets.AsQueryable();
     }
 
-    private async Task OnStatusChanged(UserContributionStatus value)
+    private void OnStatusChanged(UserContributionStatus value)
     {
-        selectedStatus = value;
-        await RefreshList();
+        // Update the URL; OnParametersSetAsync re-reads the query and refreshes the list.
+        this.Navigation.NavigateTo(
+            this.Navigation.GetUriWithQueryParameter("status", value.ToString()));
     }
 }

--- a/code/TheDiscDb/Endpoints/DiscLookupEndpoints.cs
+++ b/code/TheDiscDb/Endpoints/DiscLookupEndpoints.cs
@@ -33,11 +33,13 @@ public sealed class DiscLookupEndpoints
         }
 
         await using var database = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-        var result = await DiscLookupQuery.LookupAsync(database, globalDiscId, cancellationToken);
+        // A Disc ID can be shared by several release-discs (the same pressing sold in multiple
+        // products), so return every release that carries it.
+        var results = await DiscLookupQuery.LookupAllAsync(database, globalDiscId, cancellationToken);
 
-        return result is null
+        return results.Count == 0
             ? TypedResults.NotFound()
-            : TypedResults.Json(result, JsonOptions);
+            : TypedResults.Json(results, JsonOptions);
     }
 
     private static async Task<IResult> LookupByDiscHash(string discHash, IDbContextFactory<SqlServerDataContext> dbContextFactory, CancellationToken cancellationToken)

--- a/code/TheDiscDb/GraphQL/ReleaseDiscProjectionTypeInterceptor.cs
+++ b/code/TheDiscDb/GraphQL/ReleaseDiscProjectionTypeInterceptor.cs
@@ -40,8 +40,46 @@ public class ReleaseDiscProjectionTypeInterceptor : TypeInterceptor
 
         SetResolver(typeDef, "format", static d => d.Disc?.Format);
         SetResolver(typeDef, "contentHash", static d => d.Disc?.ContentHash);
-        SetResolver(typeDef, "globalDiscId", static d => d.Disc?.GlobalDiscId);
         SetResolver(typeDef, "titles", static d => d.Disc?.Titles ?? Array.Empty<Title>());
+        SetGlobalDiscIdResolver(typeDef);
+    }
+
+    // The output globalDiscId is the pressing's *effective* id: its own stored value, or — when it
+    // stores none — the single id shared by the other release-discs of the same canonical disc (the
+    // same content sold in another product, e.g. a boxset copy referenced via .ref). This is
+    // display-only; the where-filter still binds to the stored column (see ReleaseDiscFilterType).
+    private static void SetGlobalDiscIdResolver(ObjectTypeDefinition typeDef)
+    {
+        var field = typeDef.Fields.FirstOrDefault(f => f.Name == "globalDiscId");
+        if (field is null)
+        {
+            return;
+        }
+
+        field.PureResolver = null;
+        field.Resolver = async context =>
+        {
+            var releaseDisc = context.Parent<ReleaseDisc>();
+            if (releaseDisc.DiscId <= 0)
+            {
+                return releaseDisc.GlobalDiscId;
+            }
+
+            // The stored column isn't projected once this field has a resolver, so read this
+            // release-disc's own id and its siblings' ids fresh (indexed on DiscId).
+            var dbFactory = context.Service<IDbContextFactory<SqlServerDataContext>>();
+            await using var db = dbFactory.CreateDbContext();
+            var rows = await db.ReleaseDiscs
+                .AsNoTracking()
+                .Where(rd => rd.DiscId == releaseDisc.DiscId)
+                .Select(rd => new { rd.Id, rd.GlobalDiscId })
+                .ToListAsync(context.RequestAborted);
+
+            var own = rows.FirstOrDefault(r => r.Id == releaseDisc.Id)?.GlobalDiscId;
+            return !string.IsNullOrEmpty(own)
+                ? own
+                : ReleaseDiscExtensions.EffectiveGlobalDiscId(rows.Select(r => r.GlobalDiscId));
+        };
     }
 
     private static void SetResolver<TValue>(

--- a/code/TheDiscDb/Services/DiscLookup/DiscLookupQuery.cs
+++ b/code/TheDiscDb/Services/DiscLookup/DiscLookupQuery.cs
@@ -1,6 +1,5 @@
 namespace TheDiscDb.Services.DiscLookup;
 
-using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,81 +31,111 @@ public static partial class DiscLookupQuery
         => !string.IsNullOrEmpty(discHash) && DiscHashPattern().IsMatch(discHash);
 
     /// <summary>
-    /// Returns the disc (with its titles/item mapping) whose Disc ID equals <paramref name="globalDiscId"/>
-    /// (case-insensitive), or <c>null</c> when no disc matches.
+    /// Returns <b>every</b> release-disc that carries the given Disc ID — its own stored value or,
+    /// for release-discs of the same canonical disc that don't store an id, via the shared-pressing
+    /// fallback. Ordered so the release-disc that stores the id comes first. Empty when none match.
+    /// </summary>
+    public static async Task<IReadOnlyList<DiscLookupResult>> LookupAllAsync(SqlServerDataContext database, string globalDiscId, CancellationToken cancellationToken = default)
+    {
+        var normalized = globalDiscId.ToUpperInvariant();
+
+        // Hop 1: the canonical disc(s) this id identifies (unique index seek).
+        var canonicalDiscIds = await database.ReleaseDiscs
+            .AsNoTracking()
+            .Where(rd => rd.GlobalDiscId == normalized)
+            .Select(rd => rd.DiscId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        if (canonicalDiscIds.Count == 0)
+        {
+            return [];
+        }
+
+        // Hop 2: every release-disc of those canonical discs that stores this id or nothing
+        // (FK index seek). A sibling storing a *different* id is a re-press — excluded.
+        var releaseDiscs = await BaseReleaseDiscQuery(database)
+            .Where(rd => canonicalDiscIds.Contains(rd.DiscId)
+                && (rd.GlobalDiscId == normalized || rd.GlobalDiscId == null)
+                && rd.Release != null && (rd.Release.MediaItem != null || rd.Release.Boxset != null))
+            .OrderByDescending(rd => rd.GlobalDiscId != null) // the storing release-disc first
+            .ThenBy(rd => rd.Id)
+            .ToListAsync(cancellationToken);
+
+        var results = new List<DiscLookupResult>(releaseDiscs.Count);
+        foreach (var releaseDisc in releaseDiscs)
+        {
+            if (releaseDisc.Disc is not null)
+            {
+                results.Add(await BuildResultAsync(database, releaseDisc, normalized, cancellationToken));
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Returns the first release-disc carrying <paramref name="globalDiscId"/> (see
+    /// <see cref="LookupAllAsync"/>), or <c>null</c> when none matches.
     /// </summary>
     public static async Task<DiscLookupResult?> LookupAsync(SqlServerDataContext database, string globalDiscId, CancellationToken cancellationToken = default)
     {
-        var normalized = globalDiscId.ToUpperInvariant();
-        var disc = await LoadDiscAsync(
-            database,
-            d => d.GlobalDiscId == normalized,
-            cancellationToken);
-
-        return disc is null
-            ? null
-            : await BuildResultAsync(database, disc, cancellationToken);
+        var all = await LookupAllAsync(database, globalDiscId, cancellationToken);
+        return all.Count == 0 ? null : all[0];
     }
 
     public static async Task<DiscLookupResult?> LookupByDiscHashAsync(SqlServerDataContext database, string discHash, CancellationToken cancellationToken = default)
     {
         var normalized = discHash.ToUpperInvariant();
-        var disc = await LoadDiscAsync(
-            database,
-            d => d.ContentHash == normalized,
-            cancellationToken);
+        var releaseDisc = await BaseReleaseDiscQuery(database)
+            .Where(rd => rd.Disc != null && rd.Disc.ContentHash == normalized)
+            .Where(rd => rd.Release != null && (rd.Release.MediaItem != null || rd.Release.Boxset != null))
+            .OrderBy(rd => rd.Id)
+            .FirstOrDefaultAsync(cancellationToken);
 
-        return disc is null
+        return releaseDisc?.Disc is null
             ? null
-            : await BuildResultAsync(database, disc, cancellationToken);
+            : await BuildResultAsync(database, releaseDisc, releaseDisc.EffectiveGlobalDiscId(), cancellationToken);
     }
 
-    private static Task<Disc?> LoadDiscAsync(
-        SqlServerDataContext database,
-        Expression<Func<Disc, bool>> predicate,
-        CancellationToken cancellationToken)
+    private static IQueryable<ReleaseDisc> BaseReleaseDiscQuery(SqlServerDataContext database)
     {
-        return database.Discs
+        return database.ReleaseDiscs
             .AsNoTracking()
             .AsSplitQuery()
-            .Include(d => d.Titles)
-                .ThenInclude(t => t.Item)
-                    .ThenInclude(i => i!.Chapters)
-            .Include(d => d.Titles)
-                .ThenInclude(t => t.Tracks)
-            .Include(d => d.ReleaseDiscs)
-                .ThenInclude(rd => rd.Release!)
-                    .ThenInclude(r => r.MediaItem!)
-                        .ThenInclude(m => m.Externalids)
-            .Include(d => d.ReleaseDiscs)
-                .ThenInclude(rd => rd.Release!)
-                    .ThenInclude(r => r.Boxset)
-            .Where(predicate)
-            .OrderBy(d => d.Id)
-            .FirstOrDefaultAsync(cancellationToken);
+            .Include(rd => rd.Disc!)
+                .ThenInclude(d => d.Titles)
+                    .ThenInclude(t => t.Item)
+                        .ThenInclude(i => i!.Chapters)
+            .Include(rd => rd.Disc!)
+                .ThenInclude(d => d.Titles)
+                    .ThenInclude(t => t.Tracks)
+            .Include(rd => rd.Release!)
+                .ThenInclude(r => r.MediaItem!)
+                    .ThenInclude(m => m.Externalids)
+            .Include(rd => rd.Release!)
+                .ThenInclude(r => r.Boxset);
     }
 
     private static async Task<DiscLookupResult> BuildResultAsync(
         SqlServerDataContext database,
-        Disc disc,
+        ReleaseDisc releaseDisc,
+        string? effectiveGlobalDiscId,
         CancellationToken cancellationToken)
     {
-        var releaseDisc = disc.ReleaseDiscs
-            .Where(rd => rd.Release?.MediaItem is not null || rd.Release?.Boxset is not null)
-            .OrderBy(rd => rd.Id)
-            .FirstOrDefault();
-        var release = releaseDisc?.Release;
+        var disc = releaseDisc.Disc!;
+        var release = releaseDisc.Release;
 
-        disc.Slug = releaseDisc?.Slug;
-        disc.Name = releaseDisc?.Name;
-        disc.Index = releaseDisc?.Index ?? 0;
+        disc.Slug = releaseDisc.Slug;
+        disc.Name = releaseDisc.Name;
+        disc.Index = releaseDisc.Index;
 
         var sourceRelease = release?.Boxset is null
             ? null
             : await FindSourceReleaseForBoxsetDiscAsync(
                 database,
                 release.Slug,
-                releaseDisc?.Slug,
+                releaseDisc.Slug,
                 cancellationToken);
 
         var fileNameResolver = new FileNameTemplateResolver();
@@ -117,7 +146,7 @@ public static partial class DiscLookupQuery
         var media = release?.MediaItem ?? sourceRelease?.MediaItem;
 
         return new DiscLookupResult(
-            disc.GlobalDiscId,
+            effectiveGlobalDiscId,
             disc.Format,
             disc.ContentHash,
             media is null
@@ -140,12 +169,10 @@ public static partial class DiscLookupQuery
                     release.RegionCode,
                     release.Locale,
                     release.Upc),
-            releaseDisc is null
-                ? null
-                : new DiscLookupDisc(
-                    releaseDisc.Slug,
-                    releaseDisc.Name,
-                    releaseDisc.Index),
+            new DiscLookupDisc(
+                releaseDisc.Slug,
+                releaseDisc.Name,
+                releaseDisc.Index),
             titles);
     }
 

--- a/docs/FEATURE-AACS-DISC-ID.md
+++ b/docs/FEATURE-AACS-DISC-ID.md
@@ -86,18 +86,38 @@ DB-first then batch-synced to `/data`).
 - **Surfacing/progress**: show the Disc ID (or a "help add it" CTA) on the disc detail page; a
   backfill view listing/counting discs still missing a Disc ID; a progress metric. Optional tie-in
   to Badges/leaderboard to drive participation.
-- **Guardrails**: add-only (never overwrite); if the content-hash matches but a *different* Disc ID
-  is submitted, flag for review (possible re-press/variant) rather than silently accepting.
+- **Guardrails**: add-only per pressing (never overwrite an existing id). The Disc ID lives on the
+  **`ReleaseDisc`** (the pressing), so two releases whose discs share a content hash each carry
+  their own id and never fight over one slot. A submission is a **conflict** (filed as a pending
+  change for admin review, DB untouched) when the id already belongs to a *different* release-disc,
+  or the target release-disc already resolves to a *different* id. When the release is known
+  (contribute flow / disc-detail CTA) the id is attributed to that release; a hash-only match with
+  no release context defaults to the primary/canonical `disc.json`'s release.
+- **Shared pressings & read-time fallback**: the same physical pressing is often sold in several
+  products (a standalone release + a boxset that references it via `.ref`). Those share one content
+  hash → one canonical `Disc` → the **same** Disc ID, but the id is **stored once** (on the
+  release-disc whose `disc.json` records it; a `.ref` only carries its own `globalDiscId` when it is
+  a *different* pressing/re-press). Read paths **derive** the id: a release-disc's *effective* Disc
+  ID is its own stored value, else the single distinct id shared by the other release-discs of the
+  same canonical disc (`ReleaseDiscExtensions.EffectiveGlobalDiscId`), else none when siblings
+  disagree (a re-press collision). This drives display (the GraphQL `globalDiscId` output field, the
+  disc-detail id + "help add it" CTA), coverage stats, and the backfill "already recorded" check —
+  so a shared-pressing sibling counts as filled without duplicating the id or tripping the unique
+  index.
 
 ### Phase 4 — Ecosystem (future)
 
 - **Lookup by Disc ID** → disc + item/mpls mapping (the #388 use cases: submit disc details
   without a release, MakeMKV/Jellyfin naming, re-extraction lookup).
-  - **REST** — shipped: anonymous `GET /api/disc-id/{globalDiscId}` (`DiscLookupEndpoints`)
-    returns the disc's titles and their item mapping.
+  - **REST** — shipped: anonymous `GET /api/disc-id/{globalDiscId}` (`DiscLookupEndpoints`).
+    Returns an **array** of every release that carries the id — the storing release-disc plus any
+    shared-pressing siblings (release-discs of the same canonical disc that store no id), excluding
+    re-presses that store a different id. So a query for one id finds *all* products containing that
+    pressing. The traversal is two indexed seeks (unique id index → FK `DiscId` index), tiny
+    cardinality — no scans.
   - **GraphQL** — a dedicated `discsByGlobalDiscId` resolver was **cut** (not deferred): the
-    built-in HotChocolate filter already exposes `globalDiscId` (`ReleaseDiscFilterType`), and
-    the root `mediaItems` / `boxsets` queries reach it through `releases → discs`. Clients use
+    built-in HotChocolate filter already exposes the stored `globalDiscId` (`ReleaseDiscFilterType`),
+    and the root `mediaItems` / `boxsets` queries reach it through `releases → discs`. Clients use
     the built-in nested filter instead of a bespoke resolver, e.g.:
 
     ```graphql
@@ -109,7 +129,15 @@ DB-first then batch-synced to `/data`).
     }
     ```
 
-    (`boxsets` supports the same nested path.)
+    Note the **filter** matches the *stored* id only (the release-disc that records it), whereas the
+    `globalDiscId` **output** returns the effective value (a shared-pressing sibling shows the id
+    even though it stores none) — so a disc's output `globalDiscId` can be non-null yet not be
+    matched by an equality filter on it. Use the REST endpoint when you need every release carrying a
+    shared id.
+
+
+    (`boxsets` supports the same nested path.) `ReleaseDisc.globalDiscId` and the REST response are
+    scalar (one pressing = one id).
 - `keydb.cfg` / fvonline-db cross-referencing (same Disc ID).
 - **DVD** `DVDDiscID` investigation (separate algorithm).
 - Disc-without-release **staging** (overlaps Partial Contributions / Engram).
@@ -118,8 +146,15 @@ DB-first then batch-synced to `/data`).
 ## Open questions
 
 - Field naming: `AacsDiscId` (BD/UHD-specific) vs a generic `DiscId` + `DiscIdType` (room for DVD).
-- Conflict policy when content-hash matches but Disc IDs differ (re-press variants) — review vs
-  reject vs allow-multiple.
+- ~~Conflict policy when content-hash matches but Disc IDs differ (re-press variants) — review vs
+  reject vs allow-multiple.~~ **Resolved: the Disc ID is a property of the pressing, stored as a
+  scalar `ReleaseDisc.GlobalDiscId`** (globally unique across release-discs). A canonical `Disc`
+  (keyed by `Format` + size-based `ContentHash`) represents shared *content*; distinct pressings
+  that share it are separate `ReleaseDisc` rows (a full `disc.json` and one or more `.ref`s), each
+  carrying its own id. A different id for the same content is attributed to the pressing/release it
+  belongs to (via contribute/CTA context, else the primary `disc.json`); a genuine collision (id on
+  a different pressing, or a different id on the same pressing) is filed as a conflicted change for
+  review.
 - Whether the Disc ID eventually augments/replaces the size-hash as the dedup/canonical key.
 - Manual-search fallback for backfill when no content-hash match exists (deferred for now).
 


### PR DESCRIPTION
## Summary
Reworks the AACS **Global Disc ID** model so a physical *pressing* owns the id, and adds an admin UI to resolve the Disc ID conflicts surfaced during backfill (two discs with the same content hash but different AACS ids).

### Model
- `GlobalDiscId` moves from the shared canonical `Disc` to `ReleaseDisc` (per pressing), globally unique via a filtered unique index.
- `Disc.GlobalDiscId` becomes a transient (`[NotMapped]`) import carrier.
- Read-time fallback: `ReleaseDisc.EffectiveGlobalDiscId()` returns its own id, else the single distinct id among release-discs sharing the canonical disc, else null (ambiguous).
- Data-preserving migration `MoveGlobalDiscIdToReleaseDisc` (validated against a prod backup: 1963 ids preserved).

### API / import
- GraphQL `globalDiscId` output and REST return the effective id; REST `LookupAll` returns every release sharing an id.
- `.ref` files carry an optional `globalDiscId` (the referencing pressing's own id).

### Admin conflict resolution (`/admin/changes/{id}`)
- **Attribute** the submitted id to a sibling release-disc.
- **Swap**: assign the submitted id to the target and move the target's displaced id to a chosen sibling (the only operation that overwrites an existing id; the tools file-sync applier does a snapshot-verified controlled overwrite).
- Boxset release-discs are excluded as attribution targets (they inherit their disc from an item release).

### Admin UX
- `/admin` and `/admin/changes` persist the selected status in a `?status=` query-string param so it survives navigation.

## Testing
- Web unit tests: **645 passing** (incl. new Disc ID conflict-resolution/attribute/swap/boxset-exclusion tests).
- Verified end-to-end against a restored+migrated prod backup.

## Deployment notes
- Requires running the EF migration `MoveGlobalDiscIdToReleaseDisc`.
- A companion **tools** repo change (ContributionBuddy `EditSuggestionFileApplier` controlled overwrite + `.ref` write-back) is required for `/data` sync and will be a separate PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
